### PR TITLE
Adding IPv6 support instead of IPv4

### DIFF
--- a/src/kudu/rpc/server_negotiation.cc
+++ b/src/kudu/rpc/server_negotiation.cc
@@ -74,13 +74,14 @@ TAG_FLAG(rpc_inject_invalid_authn_token_ratio, unsafe);
 
 DECLARE_bool(rpc_encrypt_loopback_connections);
 
+// Trusting everything for now.
 DEFINE_string(trusted_subnets,
-              "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16",
+              "::/0",
               "A trusted subnet whitelist. If set explicitly, all unauthenticated "
               "or unencrypted connections are prohibited except the ones from the "
-              "specified address blocks. Otherwise, private network (127.0.0.0/8, etc.) "
+              "specified address blocks. Otherwise, private network (::1/128, etc.) "
               "and local subnets of all local network interfaces will be used. Set it "
-              "to '0.0.0.0/0' to allow unauthenticated/unencrypted connections from all "
+              "to '::/0' to allow unauthenticated/unencrypted connections from all "
               "remote IP addresses. However, if network access is not otherwise restricted "
               "by a firewall, malicious users may be able to gain unauthorized access.");
 TAG_FLAG(trusted_subnets, advanced);

--- a/src/kudu/util/net/net_util.h
+++ b/src/kudu/util/net/net_util.h
@@ -99,11 +99,11 @@ struct HostPortEqualityPredicate {
 class Network {
  public:
   Network();
-  Network(uint32_t addr, uint32_t netmask);
+  Network(uint128 addr, uint128 netmask);
 
-  uint32_t addr() const { return addr_; }
+  uint128 addr() const { return addr_; }
 
-  uint32_t netmask() const { return netmask_; }
+  uint128 netmask() const { return netmask_; }
 
   // Returns true if the address is within network.
   bool WithinNetwork(const Sockaddr& addr) const;
@@ -116,8 +116,8 @@ class Network {
   static Status ParseCIDRStrings(
       const std::string& comma_sep_addrs, std::vector<Network>* res);
  private:
-  uint32_t addr_;
-  uint32_t netmask_;
+  uint128 addr_;
+  uint128 netmask_;
 };
 
 // Parse and resolve the given comma-separated list of addresses.

--- a/src/kudu/util/net/sockaddr.h
+++ b/src/kudu/util/net/sockaddr.h
@@ -30,14 +30,12 @@ namespace kudu {
 ///
 /// Represents a sockaddr.
 ///
-/// Currently only IPv4 is implemented.  When IPv6 and UNIX domain are
-/// implemented, this should become an abstract base class and those should be
-/// multiple implementations.
+/// Currently only IPv6 is implemented.
 ///
 class Sockaddr {
  public:
   Sockaddr();
-  explicit Sockaddr(const struct sockaddr_in &addr);
+  explicit Sockaddr(const struct sockaddr_in6 &addr);
 
   // Parse a string IP address of the form "A.B.C.D:port", storing the result
   // in this Sockaddr object. If no ':port' is specified, uses 'default_port'.
@@ -46,7 +44,7 @@ class Sockaddr {
   // Returns a bad Status if the input is malformed.
   Status ParseString(const std::string& s, uint16_t default_port);
 
-  Sockaddr& operator=(const struct sockaddr_in &addr);
+  Sockaddr& operator=(const struct sockaddr_in6 &addr);
 
   bool operator==(const Sockaddr& other) const;
 
@@ -54,14 +52,14 @@ class Sockaddr {
   // The port number is ignored in this comparison.
   bool operator<(const Sockaddr &rhs) const;
 
-  uint32_t HashCode() const;
+  uint64 HashCode() const;
 
   // Returns the dotted-decimal string '1.2.3.4' of the host component of this address.
   std::string host() const;
 
   void set_port(int port);
   int port() const;
-  const struct sockaddr_in& addr() const;
+  const struct sockaddr_in6& addr() const;
 
   // Returns the stringified address in '1.2.3.4:<port>' format.
   std::string ToString() const;
@@ -77,7 +75,7 @@ class Sockaddr {
 
   // the default auto-generated copy constructor is fine here
  private:
-  struct sockaddr_in addr_;
+  struct sockaddr_in6 addr_;
 };
 
 } // namespace kudu

--- a/src/kudu/util/net/socket.cc
+++ b/src/kudu/util/net/socket.cc
@@ -132,7 +132,7 @@ bool Socket::IsTemporarySocketError(int err) {
 
 Status Socket::Init(int flags) {
   int nonblocking_flag = (flags & FLAG_NONBLOCKING) ? SOCK_NONBLOCK : 0;
-  Reset(::socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC | nonblocking_flag, 0));
+  Reset(::socket(AF_INET6, SOCK_STREAM | SOCK_CLOEXEC | nonblocking_flag, 0));
   if (fd_ < 0) {
     int err = errno;
     return Status::NetworkError("error opening socket", ErrnoToString(err), err);
@@ -144,7 +144,7 @@ Status Socket::Init(int flags) {
 #else
 
 Status Socket::Init(int flags) {
-  Reset(::socket(AF_INET, SOCK_STREAM, 0));
+  Reset(::socket(AF_INET6, SOCK_STREAM, 0));
   if (fd_ < 0) {
     int err = errno;
     return Status::NetworkError("error opening socket", ErrnoToString(err), err);
@@ -272,7 +272,7 @@ Status Socket::Listen(int listen_queue_size) {
 }
 
 Status Socket::GetSocketAddress(Sockaddr *cur_addr) const {
-  struct sockaddr_in sin;
+  struct sockaddr_in6 sin;
   socklen_t len = sizeof(sin);
   DCHECK_GE(fd_, 0);
   if (::getsockname(fd_, reinterpret_cast<struct sockaddr*>(&sin), &len) == -1) {
@@ -284,7 +284,7 @@ Status Socket::GetSocketAddress(Sockaddr *cur_addr) const {
 }
 
 Status Socket::GetPeerAddress(Sockaddr *cur_addr) const {
-  struct sockaddr_in sin;
+  struct sockaddr_in6 sin;
   socklen_t len = sizeof(sin);
   DCHECK_GE(fd_, 0);
   if (::getpeername(fd_, reinterpret_cast<struct sockaddr*>(&sin), &len) == -1) {
@@ -307,7 +307,7 @@ bool Socket::IsLoopbackConnection() const {
 }
 
 Status Socket::Bind(const Sockaddr& bind_addr) {
-  struct sockaddr_in addr = bind_addr.addr();
+  struct sockaddr_in6 addr = bind_addr.addr();
 
   DCHECK_GE(fd_, 0);
   if (PREDICT_FALSE(::bind(fd_, (struct sockaddr*) &addr, sizeof(addr)))) {
@@ -328,7 +328,7 @@ Status Socket::Bind(const Sockaddr& bind_addr) {
 
 Status Socket::Accept(Socket *new_conn, Sockaddr *remote, int flags) {
   TRACE_EVENT0("net", "Socket::Accept");
-  struct sockaddr_in addr;
+  struct sockaddr_in6 addr;
   socklen_t olen = sizeof(addr);
   DCHECK_GE(fd_, 0);
 #if defined(__linux__)
@@ -381,8 +381,8 @@ Status Socket::Connect(const Sockaddr &remote) {
     RETURN_NOT_OK(BindForOutgoingConnection());
   }
 
-  struct sockaddr_in addr;
-  memcpy(&addr, &remote.addr(), sizeof(sockaddr_in));
+  struct sockaddr_in6 addr;
+  memcpy(&addr, &remote.addr(), sizeof(sockaddr_in6));
   DCHECK_GE(fd_, 0);
   int ret;
   RETRY_ON_EINTR(ret, ::connect(


### PR DESCRIPTION
This diff replaces support for IPv4 addresses with IPv6 addresses. The implementation of the `Network` class and the `SockAddr` class has changed in this diff. Instead of using language supported 128 bit integers (https://gcc.gnu.org/onlinedocs/gcc/_005f_005fint128.html), I am using Kudu's implementation. The parsing of CIDR subnets need a little more formal treatment but I will followup.