### PR TITLE
Flow changes which allow set of instances to bootstrap and other changes

### DIFF
--- a/src/kudu/consensus/consensus_peers-test.cc
+++ b/src/kudu/consensus/consensus_peers-test.cc
@@ -53,7 +53,7 @@
 #include "kudu/rpc/messenger.h"
 //#include "kudu/tserver/tserver.pb.h"
 #include "kudu/util/metrics.h"
-METRIC_DEFINE_entity(tablet);
+//METRIC_DEFINE_entity(tablet);
 #include "kudu/util/monotime.h"
 #include "kudu/util/status.h"
 #include "kudu/util/test_macros.h"
@@ -80,7 +80,7 @@ const char* kFollowerUuid = "peer-1";
 class ConsensusPeersTest : public KuduTest {
  public:
   ConsensusPeersTest()
-    : metric_entity_(METRIC_ENTITY_tablet.Instantiate(&metric_registry_, "peer-test"))
+    : metric_entity_(METRIC_ENTITY_server.Instantiate(&metric_registry_, "peer-test"))
 #ifdef FB_DO_NOT_REMOVE
       , schema_(GetSimpleTestSchema()) 
 #endif

--- a/src/kudu/consensus/consensus_queue-test.cc
+++ b/src/kudu/consensus/consensus_queue-test.cc
@@ -58,7 +58,7 @@
 #include "kudu/gutil/ref_counted.h"
 #include "kudu/util/async_util.h"
 #include "kudu/util/metrics.h"
-METRIC_DEFINE_entity(tablet);
+//METRIC_DEFINE_entity(tablet);
 #include "kudu/util/monotime.h"
 #include "kudu/util/pb_util.h"
 #include "kudu/util/status.h"
@@ -86,7 +86,7 @@ class ConsensusQueueTest : public KuduTest {
 #ifdef FB_DO_NOT_REMOVE
         schema_(GetSimpleTestSchema()),
 #endif
-        metric_entity_(METRIC_ENTITY_tablet.Instantiate(&metric_registry_, "queue-test")),
+        metric_entity_(METRIC_ENTITY_server.Instantiate(&metric_registry_, "queue-test")),
         registry_(new log::LogAnchorRegistry) {
   }
 

--- a/src/kudu/consensus/log-test-base.h
+++ b/src/kudu/consensus/log-test-base.h
@@ -59,7 +59,7 @@
 #include "kudu/util/test_macros.h"
 #include "kudu/util/test_util.h"
 
-METRIC_DECLARE_entity(tablet);
+//METRIC_DECLARE_entity(tablet);
 
 namespace kudu {
 namespace log {
@@ -163,7 +163,7 @@ class LogTestBase : public KuduTest {
     current_index_ = kStartIndex;
     fs_manager_.reset(new FsManager(env_, GetTestPath("fs_root")));
     metric_registry_.reset(new MetricRegistry());
-    metric_entity_ = METRIC_ENTITY_tablet.Instantiate(metric_registry_.get(), "log-test-base");
+    metric_entity_ = METRIC_ENTITY_server.Instantiate(metric_registry_.get(), "log-test-base");
     ASSERT_OK(fs_manager_->CreateInitialFileSystemLayout());
     ASSERT_OK(fs_manager_->Open());
 

--- a/src/kudu/consensus/log_cache-test.cc
+++ b/src/kudu/consensus/log_cache-test.cc
@@ -63,7 +63,7 @@ using strings::Substitute;
 DECLARE_int32(log_cache_size_limit_mb);
 DECLARE_int32(global_log_cache_size_limit_mb);
 
-METRIC_DECLARE_entity(tablet);
+//METRIC_DECLARE_entity(tablet);
 
 namespace kudu {
 namespace consensus {
@@ -75,7 +75,7 @@ class LogCacheTest : public KuduTest {
  public:
   LogCacheTest()
     : schema_(GetSimpleTestSchema()),
-      metric_entity_(METRIC_ENTITY_tablet.Instantiate(&metric_registry_, "LogCacheTest")) {
+      metric_entity_(METRIC_ENTITY_server.Instantiate(&metric_registry_, "LogCacheTest")) {
   }
 
   virtual void SetUp() OVERRIDE {

--- a/src/kudu/consensus/log_metrics.cc
+++ b/src/kudu/consensus/log_metrics.cc
@@ -19,31 +19,31 @@
 
 #include "kudu/util/metrics.h"
 
-METRIC_DEFINE_counter(tablet, log_bytes_logged, "Bytes Written to WAL",
+METRIC_DEFINE_counter(server, log_bytes_logged, "Bytes Written to WAL",
                       kudu::MetricUnit::kBytes,
                       "Number of bytes logged since service start");
 
-METRIC_DEFINE_histogram(tablet, log_sync_latency, "Log Sync Latency",
+METRIC_DEFINE_histogram(server, log_sync_latency, "Log Sync Latency",
                         kudu::MetricUnit::kMicroseconds,
                         "Microseconds spent on synchronizing the log segment file",
                         60000000LU, 2);
 
-METRIC_DEFINE_histogram(tablet, log_append_latency, "Log Append Latency",
+METRIC_DEFINE_histogram(server, log_append_latency, "Log Append Latency",
                         kudu::MetricUnit::kMicroseconds,
                         "Microseconds spent on appending to the log segment file",
                         60000000LU, 2);
 
-METRIC_DEFINE_histogram(tablet, log_group_commit_latency, "Log Group Commit Latency",
+METRIC_DEFINE_histogram(server, log_group_commit_latency, "Log Group Commit Latency",
                         kudu::MetricUnit::kMicroseconds,
                         "Microseconds spent on committing an entire group",
                         60000000LU, 2);
 
-METRIC_DEFINE_histogram(tablet, log_roll_latency, "Log Roll Latency",
+METRIC_DEFINE_histogram(server, log_roll_latency, "Log Roll Latency",
                         kudu::MetricUnit::kMicroseconds,
                         "Microseconds spent on rolling over to a new log segment file",
                         60000000LU, 2);
 
-METRIC_DEFINE_histogram(tablet, log_entry_batches_per_group, "Log Group Commit Batch Size",
+METRIC_DEFINE_histogram(server, log_entry_batches_per_group, "Log Group Commit Batch Size",
                         kudu::MetricUnit::kRequests,
                         "Number of log entry batches in a group commit group",
                         1024, 2);

--- a/src/kudu/consensus/log_reader.cc
+++ b/src/kudu/consensus/log_reader.cc
@@ -39,15 +39,15 @@
 #include "kudu/util/path_util.h"
 #include "kudu/util/pb_util.h"
 
-METRIC_DEFINE_counter(tablet, log_reader_bytes_read, "Bytes Read From Log",
+METRIC_DEFINE_counter(server, log_reader_bytes_read, "Bytes Read From Log",
                       kudu::MetricUnit::kBytes,
                       "Data read from the WAL since tablet start");
 
-METRIC_DEFINE_counter(tablet, log_reader_entries_read, "Entries Read From Log",
+METRIC_DEFINE_counter(server, log_reader_entries_read, "Entries Read From Log",
                       kudu::MetricUnit::kEntries,
                       "Number of entries read from the WAL since tablet start");
 
-METRIC_DEFINE_histogram(tablet, log_reader_read_batch_latency, "Log Read Latency",
+METRIC_DEFINE_histogram(server, log_reader_read_batch_latency, "Log Read Latency",
                         kudu::MetricUnit::kBytes,
                         "Microseconds spent reading log entry batches",
                         60000000LU, 2);

--- a/src/kudu/consensus/raft_consensus_quorum-test.cc
+++ b/src/kudu/consensus/raft_consensus_quorum-test.cc
@@ -73,7 +73,7 @@
 #include "kudu/util/async_util.h"
 #include "kudu/util/mem_tracker.h"
 #include "kudu/util/metrics.h"
-METRIC_DEFINE_entity(tablet);
+//METRIC_DEFINE_entity(tablet);
 #include "kudu/util/monotime.h"
 #include "kudu/util/pb_util.h"
 #include "kudu/util/status.h"
@@ -85,7 +85,7 @@ METRIC_DEFINE_entity(tablet);
 DECLARE_int32(raft_heartbeat_interval_ms);
 DECLARE_bool(enable_leader_failure_detection);
 
-METRIC_DECLARE_entity(tablet);
+//METRIC_DECLARE_entity(tablet);
 
 using kudu::log::Log;
 using kudu::log::LogEntryPB;
@@ -127,7 +127,7 @@ class RaftConsensusQuorumTest : public KuduTest {
 
   RaftConsensusQuorumTest()
     : clock_(clock::LogicalClock::CreateStartingAt(Timestamp(1))),
-      metric_entity_(METRIC_ENTITY_tablet.Instantiate(&metric_registry_, "raft-test"))
+      metric_entity_(METRIC_ENTITY_server.Instantiate(&metric_registry_, "raft-test"))
 #ifdef FB_DO_NOT_REMOVE
       , schema_(GetSimpleTestSchema())
 #endif

--- a/src/kudu/gutil/template_util.h
+++ b/src/kudu/gutil/template_util.h
@@ -46,8 +46,10 @@
 // Both of these outcomes means that we may be able to directly replace
 // some of these with boost equivalents.
 //
-#ifndef BASE_TEMPLATE_UTIL_H_
-#define BASE_TEMPLATE_UTIL_H_
+
+// These #defines collide with sparsehash
+#ifndef KUDU_BASE_TEMPLATE_UTIL_H_
+#define KUDU_BASE_TEMPLATE_UTIL_H_
 
 namespace base {
 
@@ -161,4 +163,4 @@ struct is_class
 
 }
 
-#endif  // BASE_TEMPLATE_UTIL_H_
+#endif  // KUDU_BASE_TEMPLATE_UTIL_H_

--- a/src/kudu/gutil/type_traits.h
+++ b/src/kudu/gutil/type_traits.h
@@ -56,8 +56,9 @@
 //   is_convertible
 // We can add more type traits as required.
 
-#ifndef BASE_TYPE_TRAITS_H_
-#define BASE_TYPE_TRAITS_H_
+// THESE #defines collide with spareshash
+#ifndef KUDU_BASE_TYPE_TRAITS_H_
+#define KUDU_BASE_TYPE_TRAITS_H_
 
 #include <utility>
 
@@ -360,4 +361,4 @@ struct is_convertible
     typedef int Dummy_Type_For_PROPAGATE_POD_FROM_TEMPLATE_ARGUMENT ATTRIBUTE_UNUSED
 #define ENFORCE_POD(TypeName) typedef int Dummy_Type_For_ENFORCE_POD ATTRIBUTE_UNUSED
 
-#endif  // BASE_TYPE_TRAITS_H_
+#endif  // KUDU_BASE_TYPE_TRAITS_H_

--- a/src/kudu/server/server_base.cc
+++ b/src/kudu/server/server_base.cc
@@ -128,7 +128,6 @@ DEFINE_string(user_acl, "*",
 TAG_FLAG(user_acl, stable);
 TAG_FLAG(user_acl, sensitive);
 
-#ifdef FB_DO_NOT_REMOVE
 DEFINE_string(principal, "kudu/_HOST",
               "Kerberos principal that this daemon will log in as. The special token "
               "_HOST will be replaced with the FQDN of the local host.");
@@ -208,7 +207,6 @@ DEFINE_string(rpc_private_key_password_cmd, "", "A Unix command whose output "
 TAG_FLAG(rpc_certificate_file, experimental);
 TAG_FLAG(rpc_private_key_file, experimental);
 TAG_FLAG(rpc_ca_certificate_file, experimental);
-#endif
 
 DEFINE_int32(rpc_default_keepalive_time_ms, 65000,
              "If an RPC connection from a client is idle for this amount of time, the server "
@@ -446,9 +444,7 @@ Status ServerBase::Init() {
   // if we're having clock problems.
   RETURN_NOT_OK_PREPEND(clock_->Init(), "Cannot initialize clock");
 
-#ifdef FB_DO_NOT_REMOVE
   RETURN_NOT_OK(security::InitKerberosForServer(FLAGS_principal, FLAGS_keytab_file));
-#endif
 
   fs::FsReport report;
   Status s = fs_manager_->Open(&report);
@@ -471,8 +467,6 @@ Status ServerBase::Init() {
   RETURN_NOT_OK(report.LogAndCheckForFatalErrors());
 
   RETURN_NOT_OK(InitAcls());
-#ifdef FB_DO_NOT_REMOVE
-#endif
 
   // Create the Messenger.
   rpc::MessengerBuilder builder(name_);
@@ -483,8 +477,6 @@ Status ServerBase::Init() {
          .set_metric_entity(metric_entity())
          .set_connection_keep_alive_time(FLAGS_rpc_default_keepalive_time_ms)
          .set_rpc_negotiation_timeout_ms(FLAGS_rpc_negotiation_timeout_ms)
-         ;
-#ifdef FB_DO_NOT_REMOVE
          .set_rpc_authentication(FLAGS_rpc_authentication)
          .set_rpc_encryption(FLAGS_rpc_encryption)
          .set_rpc_tls_ciphers(FLAGS_rpc_tls_ciphers)
@@ -494,7 +486,6 @@ Status ServerBase::Init() {
          .set_epki_private_password_key_cmd(FLAGS_rpc_private_key_password_cmd)
          .set_keytab_file(FLAGS_keytab_file)
          .enable_inbound_tls();
-#endif
 
   if (options_.rpc_opts.rpc_reuseport) {
     builder.set_reuseport();
@@ -508,9 +499,7 @@ Status ServerBase::Init() {
   RETURN_NOT_OK(rpc_server_->Bind());
   clock_->RegisterMetrics(metric_entity_);
 
-#ifdef FB_DO_NOT_REMOVE
   RETURN_NOT_OK_PREPEND(StartMetricsLogging(), "Could not enable metrics logging");
-#endif
 
   result_tracker_->StartGCThread();
   RETURN_NOT_OK(StartExcessLogFileDeleterThread());
@@ -552,8 +541,6 @@ Status ServerBase::InitAcls() {
 
   return Status::OK();
 }
-#ifdef FB_DO_NOT_REMOVE
-#endif
 
 
 Status ServerBase::GetStatusPB(ServerStatusPB* status) const {

--- a/src/kudu/tserver/tablet_server_options.h
+++ b/src/kudu/tserver/tablet_server_options.h
@@ -34,9 +34,9 @@ namespace tserver {
 struct TabletServerOptions : public kudu::server::ServerBaseOptions {
   TabletServerOptions();
 
-#ifdef FB_DO_NOT_REMOVE
-  std::vector<HostPort> master_addresses;
-#endif
+  std::vector<HostPort> tserver_addresses;
+
+  bool IsDistributed() const;
 };
 
 } // namespace tserver


### PR DESCRIPTION
Summary:

1. distributed config. Once you provide tserver addresses, the peers are
created and the config with bootstrap tserver is put onto disk for next time

2. The above allows re-entrancy. The next time the bootstrap config is already
in place and will be picked up by raft.

3. Continuing the set of changes that ritwik started by making the metrics as
server instead of tablet.Maybe we should roll this back in the future to stay
as close to upstream as possible.

4. Bring back Kerberos and messenger intializations so that a set of nodes can
talk to each other.

5. Fixing the header file collision issue with sparsehash and kudu/gutil

Test Plan: Ran unittests and all key unittests succeeded.

Brough up in fbcode a set of heartbeating servers who successfully elected
leader and did leader elections on failure. No kerberos and TLS issues were
encountered as kudu worked fine with self-signing certificates

Reviewers:

Subscribers:

Tasks:

Tags: