### PR TITLE
Log Factory and Reworking tablet manager setup steps for the same

### DIFF
--- a/src/kudu/consensus/log.cc
+++ b/src/kudu/consensus/log.cc
@@ -454,15 +454,21 @@ Status Log::Open(const LogOptions &options,
   RETURN_NOT_OK(env_util::CreateDirIfMissing(
       fs_manager->env(), tablet_wal_path));
 
-  scoped_refptr<Log> new_log(new Log(options,
-                                     fs_manager,
-                                     tablet_wal_path,
-                                     tablet_id,
+  scoped_refptr<Log> new_log;
+  if (options.log_factory) {
+    RETURN_NOT_OK(options.log_factory->createLog(options,
+        fs_manager, tablet_wal_path,
+        tablet_id, metric_entity, &new_log));
+  } else {
+    new_log = new Log(options, fs_manager,
+                     tablet_wal_path,
+                     tablet_id,
 #ifdef FB_DO_NOT_REMOVE
-                                     schema,
-                                     schema_version,
+                     schema,
+                     schema_version,
 #endif
-                                     metric_entity));
+                     metric_entity);
+  }
   RETURN_NOT_OK(new_log->Init());
   log->swap(new_log);
   return Status::OK();
@@ -497,6 +503,16 @@ Log::Log(LogOptions options, FsManager* fs_manager, string log_path,
   if (metric_entity_) {
     metrics_.reset(new LogMetrics(metric_entity_));
   }
+}
+
+Status LogFactory::createLog(LogOptions options,
+    FsManager* fs_manager, std::string log_path,
+    std::string tablet_id,
+    scoped_refptr<MetricEntity> metric_entity,
+    scoped_refptr<Log> *new_log) {
+  *new_log = new Log(options, fs_manager, log_path,
+      tablet_id, metric_entity);
+  return Status::OK();
 }
 
 Status Log::Init() {

--- a/src/kudu/consensus/log.h
+++ b/src/kudu/consensus/log.h
@@ -256,6 +256,7 @@ class Log : public RefCountedThreadSafe<Log> {
  private:
   friend class LogTest;
   friend class LogTestBase;
+  friend class LogFactory;
   FRIEND_TEST(LogTestOptionalCompression, TestMultipleEntriesInABatch);
   FRIEND_TEST(LogTestOptionalCompression, TestReadLogWithReplacedReplicates);
   FRIEND_TEST(LogTest, TestWriteAndReadToAndFromInProgressSegment);
@@ -435,6 +436,21 @@ class Log : public RefCountedThreadSafe<Log> {
   std::atomic<int64_t> on_disk_size_;
 
   DISALLOW_COPY_AND_ASSIGN(Log);
+};
+
+// Log Factory which enables the Raft based application
+// to create the appropriate log implementation.
+// Application e.g. MySQL is expected to specialize
+// the LogFactory class to create the derived log implementation
+// object.
+class LogFactory {
+public:
+  virtual ~LogFactory() {}
+  virtual Status createLog(LogOptions options,
+      FsManager* fs_manager, std::string log_path,
+      std::string tablet_id,
+      scoped_refptr<MetricEntity> metric_entity,
+      scoped_refptr<Log> *new_log);
 };
 
 // Indicates which log indexes should be retained for different purposes.

--- a/src/kudu/consensus/log_util.h
+++ b/src/kudu/consensus/log_util.h
@@ -49,6 +49,8 @@ class CompressionCodec;
 
 namespace log {
 
+class LogFactory;
+
 // Each log entry is prefixed by a header. See DecodeEntryHeader()
 // implementation for details.
 extern const size_t kEntryHeaderSizeV2;
@@ -72,6 +74,8 @@ struct LogOptions {
 
   // Whether the allocation should happen asynchronously.
   bool async_preallocate_segments;
+
+  std::shared_ptr<LogFactory> log_factory;
 
   LogOptions();
 };

--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -2663,6 +2663,12 @@ void RaftConsensus::DoElectionCallback(ElectionReason reason, const ElectionResu
   }
 }
 
+boost::optional<OpId> RaftConsensus::GetNextOpId() const {
+  LockGuard l(lock_);
+  if (!queue_) return boost::none;
+  return queue_->GetNextOpId();
+}
+
 boost::optional<OpId> RaftConsensus::GetLastOpId(OpIdType type) {
   ThreadRestrictions::AssertWaitAllowed();
   LockGuard l(lock_);

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -323,6 +323,8 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   // Returns boost::none if RaftConsensus was not properly initialized.
   boost::optional<OpId> GetLastOpId(OpIdType type);
 
+  boost::optional<OpId> GetNextOpId() const;
+
   // Returns the current Raft role of this instance.
   RaftPeerPB::Role role() const;
 

--- a/src/kudu/server/server_base.cc
+++ b/src/kudu/server/server_base.cc
@@ -496,6 +496,9 @@ Status ServerBase::Init() {
       &ServerBase::ServiceQueueOverflowed, this, std::placeholders::_1));
 
   RETURN_NOT_OK(rpc_server_->Init(messenger_));
+
+  // Bind the RPC server so that the
+  // local raft peer can be initialized
   RETURN_NOT_OK(rpc_server_->Bind());
   clock_->RegisterMetrics(metric_entity_);
 

--- a/src/kudu/tserver/simple_tablet_manager.h
+++ b/src/kudu/tserver/simple_tablet_manager.h
@@ -52,6 +52,11 @@ class NodeInstancePB;
 class ThreadPool;
 class MonoDelta;
 
+namespace log {
+
+class Log;
+}
+
 namespace consensus {
 class ConsensusMetadataManager;
 class OpId;
@@ -82,7 +87,11 @@ class TSTabletManager : public consensus::ConsensusRoundHandler {
   // the bootstrap is performed asynchronously.
   Status Init(bool is_first_run);
 
+  Status Start();
+
   bool IsInitialized() const;
+
+  bool IsRunning() const;
 
   // Shut down all of the tablets, gracefully flushing before shutdown.
   void Shutdown();
@@ -139,10 +148,10 @@ class TSTabletManager : public consensus::ConsensusRoundHandler {
   // Create either a standalone or distributed config
   Status CreateNew(FsManager *fs_manager);
 
-  // Helper function to create and start the Raft consensus
+  // Helper function to create Raft consensus and log
+  // Consensus is yet to be started at the end of this
+  // call.
   Status SetupRaft();
-
-  Status InitRaftAsync(bool is_first_run);
 
   // Initializes the RaftPeerPB for the local peer.
   // Guaranteed to include both uuid and last_seen_addr fields.
@@ -158,6 +167,10 @@ class TSTabletManager : public consensus::ConsensusRoundHandler {
   FsManager* const fs_manager_;
 
   const scoped_refptr<consensus::ConsensusMetadataManager> cmeta_manager_;
+
+  // Kudu log, which was created by the passed in
+  // factory entity
+  scoped_refptr<kudu::log::Log> log_;
 
   TabletServer* server_;
 

--- a/src/kudu/tserver/tablet_server.h
+++ b/src/kudu/tserver/tablet_server.h
@@ -62,9 +62,14 @@ class TabletServer : public kserver::KuduServer {
   // Some initialization tasks are asynchronous, such as the bootstrapping
   // of tablets. Caller can block, waiting for the initialization to fully
   // complete by calling WaitInited().
+  // RPC server is created and addresses bound
+  // Tablet manager is initialized
+  // Raft is created.
+  // Raft log is created.
   virtual Status Init() override;
 
   virtual Status Start() override;
+
   virtual void Shutdown() override;
 
   std::string ToString() const;
@@ -95,12 +100,6 @@ class TabletServer : public kserver::KuduServer {
  private:
   friend class TabletServerTestBase;
 
-  Status StartAsync();
-  Status WaitForTabletManagerInit() const;
-
-  void InitTabletManagerTask();
-  Status InitTabletManager();
-
 #ifdef FB_DO_NOT_REMOVE
   Status ValidateMasterAddressResolution() const;
 #endif
@@ -114,10 +113,6 @@ class TabletServer : public kserver::KuduServer {
 
   // For initializing the catalog manager.
   gscoped_ptr<ThreadPool> init_pool_;
-
-  // The status of the master initialization. This is set
-  // by the async initialization task.
-  Promise<Status> init_status_;
 
   // The options passed at construction time.
   const TabletServerOptions opts_;

--- a/src/kudu/tserver/tablet_server_options.h
+++ b/src/kudu/tserver/tablet_server_options.h
@@ -18,11 +18,16 @@
 #define KUDU_TSERVER_TABLET_SERVER_OPTIONS_H
 
 #include <vector>
+#include <memory>
 
 #include "kudu/server/server_base_options.h"
 #include "kudu/util/net/net_util.h"
 
 namespace kudu {
+namespace log {
+class LogFactory;
+}
+
 namespace tserver {
 
 // Options for constructing a tablet server.
@@ -35,6 +40,8 @@ struct TabletServerOptions : public kudu::server::ServerBaseOptions {
   TabletServerOptions();
 
   std::vector<HostPort> tserver_addresses;
+
+  std::shared_ptr<kudu::log::LogFactory> log_factory;
 
   bool IsDistributed() const;
 };

--- a/src/kudu/tserver/tserver_admin.proto
+++ b/src/kudu/tserver/tserver_admin.proto
@@ -27,14 +27,18 @@ enum TSTabletManagerStatePB {
   // Indicates that Tablet Manager is initializing.
   MANAGER_INITIALIZING = 0;
 
-  // Indicates that Tablet Manager is running and can create new
-  // tablets.
-  MANAGER_RUNNING = 1;
+  // Indicates that Tablet Manager is initialized and
+  // Raft data structures e.g. consensus and log have been created.
+  // However Raft has not yet started
+  MANAGER_INITIALIZED = 1;
+
+  // Indicates that Raft is running for the simple tablet manager
+  MANAGER_RUNNING = 2;
 
   // Indicates that tablet manager is shutting down and no new tablets
   // can be created.
-  MANAGER_QUIESCING = 2;
+  MANAGER_QUIESCING = 3;
 
   // Tablet Manager has shutdown.
-  MANAGER_SHUTDOWN = 3;
+  MANAGER_SHUTDOWN = 4;
 }


### PR DESCRIPTION
Summary:
1. Creating a log factory class which can be passed in server options
 The passed in log factory will be used to create the log implementation

2. Reworking how setup is done in the tablet server so that we can
create the log and consensus before we actually start consensus.

Test Plan: Tested this in shadow setups using MySQL replication

Reviewers: iRitwik

Subscribers:

Tasks:

Tags: