### PR TITLE
make log functions protected members so that BinlogWrapper can use it.

### DIFF
--- a/src/kudu/consensus/log.h
+++ b/src/kudu/consensus/log.h
@@ -268,7 +268,7 @@ class Log : public RefCountedThreadSafe<Log> {
       std::vector<consensus::ReplicateMsg*>* replicates) const;
   virtual Status LookupOpId(int64_t op_index, consensus::OpId* op_id) const;
 
- private:
+ protected:
   friend class LogTest;
   friend class LogTestBase;
   friend class LogFactory;


### PR DESCRIPTION
Summary: This was a typo from previous PR#7 when I had missed out on the
protected part while merging changes.

Test Plan: Made MySQL binlog wrapper compile

Reviewers: iRitwik

Subscribers:

Tasks:

Tags: