### PR TITLE
Removing curl_util.cc from compilation in order to remove curl and li…

### DIFF
--- a/src/kudu/util/CMakeLists.txt
+++ b/src/kudu/util/CMakeLists.txt
@@ -322,15 +322,15 @@ endif()
 #######################################
 # kudu_curl_util
 #######################################
-if(NOT NO_TESTS)
-  add_library(kudu_curl_util
-    curl_util.cc)
-  target_link_libraries(kudu_curl_util
-    security
-    ${CURL_LIBRARIES}
-    glog
-    gutil)
-endif()
+#if(NOT NO_TESTS)
+#  add_library(kudu_curl_util
+#    curl_util.cc)
+#  target_link_libraries(kudu_curl_util
+#    security
+#    ${CURL_LIBRARIES}
+#    glog
+#    gutil)
+#endif()
 
 #######################################
 # kudu_test_main


### PR DESCRIPTION
…bssh2 from dependencies

Summary: This file was not used anywhere in kudu library, and is causing
issues during tp2 updates. Recent example was due to libssh2 1.9 version upgrade.
Removing it since, we don't need it.

Test Plan: Test with new artifacts in tp2 which we have already published

Reviewers:iRitwik

Subscribers:

Tasks:

Tags: