### PR TITLE
TruncateOps call should call underlying log implementation+ disable no-op support

### DIFF
--- a/src/kudu/consensus/log.cc
+++ b/src/kudu/consensus/log.cc
@@ -854,6 +854,13 @@ Status Log::WaitUntilAllFlushed() {
   return s.Wait();
 }
 
+Status Log::TruncateOpsAfter(int64_t index) {
+  // In base implementation, truncation is not needed
+  // as next_sequential_op_index_ is updated, as an alternative
+  // to actual trimming
+  return Status::OK();
+}
+
 Status Log::GC(RetentionIndexes retention_indexes, int32_t* num_gced) {
   CHECK_GE(retention_indexes.for_durability, 0);
 

--- a/src/kudu/consensus/log.h
+++ b/src/kudu/consensus/log.h
@@ -138,6 +138,8 @@ class Log : public RefCountedThreadSafe<Log> {
   // are flushed and fsynced (if fsync of log entries is enabled).
   virtual Status WaitUntilAllFlushed();
 
+  virtual Status TruncateOpsAfter(int64_t index);
+
   // Kick off an asynchronous task that pre-allocates a new
   // log-segment, setting 'allocation_status_'. To wait for the
   // result of the task, use allocation_status_.Get().

--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -202,6 +202,7 @@ RaftConsensus::RaftConsensus(
       withhold_votes_until_(MonoTime::Min()),
       last_received_cur_leader_(MinimumOpId()),
       failed_elections_since_stable_leader_(0),
+      disable_noop_(false),
       shutdown_(false),
       update_calls_for_tests_(0) {
   DCHECK(local_peer_pb_.has_permanent_uuid());
@@ -683,6 +684,10 @@ Status RaftConsensus::BecomeLeaderUnlocked() {
 
   queue_->RegisterObserver(this);
   RETURN_NOT_OK(RefreshConsensusQueueAndPeersUnlocked());
+
+  if (disable_noop_) {
+    return Status::OK();
+  }
 
   // Initiate a NO_OP transaction that is sent at the beginning of every term
   // change in raft.

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -167,6 +167,8 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
                        ThreadPool* raft_pool,
                        std::shared_ptr<RaftConsensus>* consensus_out);
 
+  void DisableNoOpEntries() { disable_noop_ = true; }
+
   // Starts running the Raft consensus algorithm.
   // Start() is not thread-safe. Calls to Start() should be externally
   // synchronized with calls accessing non-const members of this class.
@@ -934,6 +936,9 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   ElectionDecisionCallback edcb_;
   TermAdvancementCallback tacb_;
   NoOpReceivedCallback norcb_;
+
+  // this is not expected to change after a create of Raft.
+  bool disable_noop_;
 
   // A flag to help us avoid taking a lock on the reactor thread if the object
   // is already in kShutdown state.

--- a/src/kudu/tserver/simple_tablet_manager.cc
+++ b/src/kudu/tserver/simple_tablet_manager.cc
@@ -363,9 +363,18 @@ Status TSTabletManager::SetupRaft() {
                                       server_->raft_pool(),
                                       &consensus));
   consensus_ = std::move(consensus);
-  consensus_->SetElectionDecisionCallback(server_->opts().edcb);
-  consensus_->SetTermAdvancementCallback(server_->opts().tacb);
-  consensus_->SetNoOpReceivedCallback(server_->opts().norcb);
+  if (server_->opts().edcb) {
+    consensus_->SetElectionDecisionCallback(server_->opts().edcb);
+  }
+  if (server_->opts().tacb) {
+    consensus_->SetTermAdvancementCallback(server_->opts().tacb);
+  }
+  if (server_->opts().norcb) {
+    consensus_->SetNoOpReceivedCallback(server_->opts().norcb);
+  }
+  if (server_->opts().disable_noop) {
+    consensus_->DisableNoOpEntries();
+  }
 
   // set_state(INITIALIZED);
   // SetStatusMessage("Initialized. Waiting to start...");

--- a/src/kudu/tserver/tablet_server_options.h
+++ b/src/kudu/tserver/tablet_server_options.h
@@ -53,6 +53,7 @@ struct TabletServerOptions : public kudu::server::ServerBaseOptions {
   std::function<void(const consensus::ElectionResult&)> edcb;
   std::function<void(int64_t)> tacb;
   std::function<void(const consensus::OpId id)> norcb;
+  bool disable_noop = false;
 
   bool IsDistributed() const;
 };


### PR DESCRIPTION
Summary:

1. support for truncate ops
2. disable no op message support through options
3. make edcb, tacb, norcb optional so that CHECK does not fail
   downstream

Test Plan: Build and test in shadow testing with mysql raft

Reviewers:iRitwik

Subscribers:

Tasks:

Tags: