### PR TITLE
Adding a StartConsensusOnlyRoundHandler to mimic StartFollowerTransac…

### DIFF
--- a/src/kudu/consensus/consensus-test-util.h
+++ b/src/kudu/consensus/consensus-test-util.h
@@ -722,6 +722,10 @@ class TestTransactionFactory : public ConsensusRoundHandler {
     return Status::OK();
   }
 
+  Status StartConsensusOnlyRound(const scoped_refptr<ConsensusRound>& round) override {
+    return Status::OK();
+  }
+
   void FinishConsensusOnlyRound(ConsensusRound* /*round*/) override {}
 
   void ReplicateAsync(ConsensusRound* round) {

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -1011,6 +1011,8 @@ class ConsensusRoundHandler {
 
   virtual Status StartFollowerTransaction(const scoped_refptr<ConsensusRound>& context) = 0;
 
+  virtual Status StartConsensusOnlyRound(const scoped_refptr<ConsensusRound>& context) = 0;
+
   // Consensus-only rounds complete when non-transaction ops finish
   // replication. This can be used to trigger callbacks, akin to an Apply() for
   // transaction ops.

--- a/src/kudu/tserver/simple_tablet_manager.cc
+++ b/src/kudu/tserver/simple_tablet_manager.cc
@@ -442,6 +442,13 @@ string TSTabletManager::LogPrefix() const {
   return LogPrefix(kSysCatalogTabletId);
 }
 
+Status TSTabletManager::StartConsensusOnlyRound(
+      const scoped_refptr<consensus::ConsensusRound>& round) {
+  // this is currently a no-op but other implementations
+  // can provide their own version
+  return Status::OK();
+}
+
 Status TSTabletManager::StartFollowerTransaction(const scoped_refptr<ConsensusRound>& round) {
   // THIS IS CURRENTLY A NO-OP
   consensus::ReplicateMsg* replicate_msg = round->replicate_msg();

--- a/src/kudu/tserver/simple_tablet_manager.h
+++ b/src/kudu/tserver/simple_tablet_manager.h
@@ -107,6 +107,9 @@ class TSTabletManager : public consensus::ConsensusRoundHandler {
   // has finished, advancing MVCC safe time as appropriate.
   virtual void FinishConsensusOnlyRound(consensus::ConsensusRound* round) override;
 
+  virtual Status StartConsensusOnlyRound(
+      const scoped_refptr<consensus::ConsensusRound>& round) override;
+
   std::shared_ptr<consensus::RaftConsensus> shared_consensus() const {
     shared_lock<RWMutex> l(lock_);
     return consensus_;


### PR DESCRIPTION
…tion

Summary: This is a call to a derived round handler in sync mode
which enables it to reject the update (say if the log is not ready)
and also to do additional bookkeeping (e.g. for starting to buffer
post rotate events )

Test Plan: Tested it inside mysql mtr for Live Master promotion.
Without this, we were not able to stop events after rotate events
to go to the same file.

Reviewers: iRitwik, bhatvinay

Subscribers:

Tasks:

Tags: