### PR TITLE
Removing kernel stack watchdog debug build, some other fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,9 +437,9 @@ endif()
 
 # If we still don't know what kind of linking to perform, choose based on
 # build type (developers like fast builds).
+# We do DEBUG builds in static lib mode
 if ("${KUDU_LINK}" STREQUAL "a")
-  if ("${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG" OR
-      "${CMAKE_BUILD_TYPE}" STREQUAL "FASTDEBUG")
+  if ("${CMAKE_BUILD_TYPE}" STREQUAL "FASTDEBUG")
     message("Using dynamic linking for ${CMAKE_BUILD_TYPE} builds")
     set(KUDU_LINK "d")
   else()

--- a/build-support/build-kuduraft.sh
+++ b/build-support/build-kuduraft.sh
@@ -20,6 +20,5 @@ build-support/enable_devtoolset.sh thirdparty/build-if-necessary.sh
 
 mkdir -p build/release
 cd build/release
-../../build-support/enable_devtoolset.sh \
-  cmake -DCMAKE_BUILD_TYPE=release ../..
+../../build-support/enable_devtoolset.sh cmake -DCMAKE_BUILD_TYPE=release ../..
 make -j20

--- a/cmake_modules/FindLz4.cmake
+++ b/cmake_modules/FindLz4.cmake
@@ -25,7 +25,7 @@ find_path(LZ4_INCLUDE_DIR lz4.h
   # make sure we don't accidentally pick up a different version
   NO_CMAKE_SYSTEM_PATH
   NO_SYSTEM_ENVIRONMENT_PATH)
-find_library(LZ4_STATIC_LIB liblz4.a
+find_library(LZ4_STATIC_LIB NAMES liblz4_pic.a liblz4.a
   NO_CMAKE_SYSTEM_PATH
   NO_SYSTEM_ENVIRONMENT_PATH)
 

--- a/src/kudu/consensus/consensus_peers.cc
+++ b/src/kudu/consensus/consensus_peers.cc
@@ -503,8 +503,10 @@ Peer::~Peer() {
 
 RpcPeerProxy::RpcPeerProxy(gscoped_ptr<HostPort> hostport,
                            gscoped_ptr<ConsensusServiceProxy> consensus_proxy)
-    : hostport_(std::move(DCHECK_NOTNULL(hostport))),
-      consensus_proxy_(std::move(DCHECK_NOTNULL(consensus_proxy))) {
+    : hostport_(std::move(hostport)),
+      consensus_proxy_(std::move(consensus_proxy)) {
+  DCHECK(hostport_ != NULL);
+  DCHECK(consensus_proxy_ != NULL);
 }
 
 void RpcPeerProxy::UpdateAsync(const ConsensusRequestPB* request,

--- a/src/kudu/consensus/log.cc
+++ b/src/kudu/consensus/log.cc
@@ -399,7 +399,7 @@ void Log::AppendThread::HandleGroup(vector<LogEntryBatch*> entry_batches) {
   } else {
     TRACE_EVENT0("log", "Callbacks");
     VLOG_WITH_PREFIX(2) << "Synchronized " << entry_batches.size() << " entry batches";
-    SCOPED_WATCH_STACK(100);
+    SCOPED_WATCH_STACK(0);
     for (LogEntryBatch* entry_batch : entry_batches) {
       if (PREDICT_TRUE(!entry_batch->callback().is_null())) {
         entry_batch->callback().Run(Status::OK());
@@ -698,7 +698,7 @@ Status Log::DoAppend(LogEntryBatch* entry_batch) {
 
   LOG_SLOW_EXECUTION(WARNING, 50, Substitute("$0Append to log took a long time", LogPrefix())) {
     SCOPED_LATENCY_METRIC(metrics_, append_latency);
-    SCOPED_WATCH_STACK(500);
+    SCOPED_WATCH_STACK(0);
 
     RETURN_NOT_OK(active_segment_->WriteEntryBatch(entry_batch_data, codec_));
 

--- a/src/kudu/consensus/log.h
+++ b/src/kudu/consensus/log.h
@@ -117,6 +117,9 @@ class Log : public RefCountedThreadSafe<Log> {
 
   virtual ~Log();
 
+  // Initializes a new one or continues an existing log.
+  virtual Status Init();
+
   // Synchronously append a new entry to the log.
   // Log does not take ownership of the passed 'entry'.
   virtual Status Append(LogEntryPB* entry);
@@ -300,9 +303,6 @@ class Log : public RefCountedThreadSafe<Log> {
       const Schema& schema, uint32_t schema_version,
 #endif
       scoped_refptr<MetricEntity> metric_entity);
-
-  // Initializes a new one or continues an existing log.
-  Status Init();
 
   // Make segments roll over.
   Status RollOver();

--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -194,7 +194,7 @@ RaftConsensus::RaftConsensus(
     ThreadPool* raft_pool)
     : options_(std::move(options)),
       local_peer_pb_(std::move(local_peer_pb)),
-      cmeta_manager_(DCHECK_NOTNULL(std::move(cmeta_manager))),
+      cmeta_manager_(std::move(cmeta_manager)),
       raft_pool_(raft_pool),
       state_(kNew),
       rng_(GetRandomSeed32()),
@@ -206,6 +206,7 @@ RaftConsensus::RaftConsensus(
       shutdown_(false),
       update_calls_for_tests_(0) {
   DCHECK(local_peer_pb_.has_permanent_uuid());
+  DCHECK(cmeta_manager_ != NULL);
 }
 
 Status RaftConsensus::Init() {
@@ -242,11 +243,15 @@ Status RaftConsensus::Start(const ConsensusBootstrapInfo& info,
                             Callback<void(const std::string& reason)> mark_dirty_clbk) {
   DCHECK(metric_entity);
 
-  peer_proxy_factory_ = DCHECK_NOTNULL(std::move(peer_proxy_factory));
-  log_ = DCHECK_NOTNULL(std::move(log));
-  time_manager_ = DCHECK_NOTNULL(std::move(time_manager));
+  peer_proxy_factory_ = std::move(peer_proxy_factory);
+  log_ = std::move(log);
+  time_manager_ = std::move(time_manager);
   round_handler_ = DCHECK_NOTNULL(round_handler);
   mark_dirty_clbk_ = std::move(mark_dirty_clbk);
+
+  DCHECK(peer_proxy_factory_ != NULL);
+  DCHECK(log_ != NULL);
+  DCHECK(time_manager_ != NULL);
 
   term_metric_ = metric_entity->FindOrCreateGauge(&METRIC_raft_term, CurrentTerm());
   follower_memory_pressure_rejections_ =
@@ -2950,7 +2955,9 @@ Status RaftConsensus::HandleTermAdvanceUnlocked(ConsensusTerm new_term,
 
 Status RaftConsensus::CheckSafeToReplicateUnlocked(const ReplicateMsg& msg) const {
   DCHECK(lock_.is_locked());
+#ifdef FB_DO_NOT_REMOVE
   DCHECK(!msg.has_id()) << "Should not have an ID yet: " << SecureShortDebugString(msg);
+#endif
   RETURN_NOT_OK(CheckRunningUnlocked());
   return CheckActiveLeaderUnlocked();
 }

--- a/src/kudu/rpc/outbound_call.cc
+++ b/src/kudu/rpc/outbound_call.cc
@@ -270,7 +270,7 @@ void OutboundCall::CallCallback() {
 
   int64_t start_cycles = CycleClock::Now();
   {
-    SCOPED_WATCH_STACK(100);
+    SCOPED_WATCH_STACK(0);
     callback_();
     // Clear the callback, since it may be holding onto reference counts
     // via bound parameters. We do this inside the timer because it's possible

--- a/src/kudu/tserver/simple_tablet_manager.cc
+++ b/src/kudu/tserver/simple_tablet_manager.cc
@@ -404,6 +404,7 @@ void TSTabletManager::Shutdown() {
         return;
       }
       case MANAGER_INITIALIZING:
+      case MANAGER_INITIALIZED:
       case MANAGER_RUNNING: {
         LOG(INFO) << "Shutting down tablet manager...";
         state_ = MANAGER_QUIESCING;

--- a/src/kudu/tserver/tablet_server_options.cc
+++ b/src/kudu/tserver/tablet_server_options.cc
@@ -52,14 +52,18 @@ TabletServerOptions::TabletServerOptions() {
       LOG(FATAL) << "Couldn't parse the tserver_addresses flag('" << FLAGS_tserver_addresses << "'): "
                  << s.ToString();
     }
+
+#ifdef FB_DO_NOT_REMOVE
+// to simplify in FB, we allow rings with single instances.
     if (tserver_addresses.size() < 2) {
       LOG(FATAL) << "At least 2 tservers are required for a distributed config, but "
           "tserver_addresses flag ('" << FLAGS_tserver_addresses << "') only specifies "
                  << tserver_addresses.size() << " tservers.";
     }
+#endif
 
     // TODO(wdberkeley): Un-actionable warning. Link to docs, once they exist.
-    if (tserver_addresses.size() == 2) {
+    if (tserver_addresses.size() <= 2) {
       LOG(WARNING) << "Only 2 tservers are specified by tserver_addresses_flag ('" <<
           FLAGS_tserver_addresses << "'), but minimum of 3 are required to tolerate failures"
           " of any one tserver. It is recommended to use at least 3 tservers.";

--- a/src/kudu/util/thread.cc
+++ b/src/kudu/util/thread.cc
@@ -552,7 +552,7 @@ Status Thread::StartThread(const std::string& category, const std::string& name,
 
   {
     SCOPED_LOG_SLOW_EXECUTION_PREFIX(WARNING, 500 /* ms */, log_prefix, "creating pthread");
-    SCOPED_WATCH_STACK((flags & NO_STACK_WATCHDOG) ? 0 : 250);
+    //SCOPED_WATCH_STACK((flags & NO_STACK_WATCHDOG) ? 0 : 250);
     int ret = pthread_create(&t->thread_, NULL, &Thread::SuperviseThread, t.get());
     if (ret) {
       return Status::RuntimeError("Could not create thread", strerror(ret), ret);


### PR DESCRIPTION
Summary:

1. comment out different instances of kernel stack watchdog
   activity by making timedelay = 0

2. support for debug build

3. replace DCHECK_NOTNULL with DCHECK's where it would fail
4. Fixing the issue with MANAGER_INITIALIZED state
5. Making Log::Init a virtual function, otherwise we will
   potentially exercise unsafe code in Wrapper mode.

Test Plan: tp2_use_local and ran the mtr test

Reviewers: iRitwik, bhatvinay

Subscribers:

Tasks:

Tags: