### PR TITLE
Make Close a virtual function in Log mimic'ing Init

### DIFF
--- a/src/kudu/consensus/log.cc
+++ b/src/kudu/consensus/log.cc
@@ -1249,7 +1249,7 @@ std::string Log::LogPrefix() const {
 }
 
 Log::~Log() {
-  WARN_NOT_OK(Close(), "Error closing log");
+  // Close() of log is now called from simple_tablet_manager
 }
 
 LogEntryBatch::LogEntryBatch(LogEntryTypePB type,

--- a/src/kudu/consensus/log.h
+++ b/src/kudu/consensus/log.h
@@ -130,6 +130,9 @@ class Log : public RefCountedThreadSafe<Log> {
       const std::vector<consensus::ReplicateRefPtr>& replicates,
       const StatusCallback& callback);
 
+  // Syncs all state and closes the log.
+  virtual Status Close();
+
   // Append the given commit message, asynchronously.
   //
   // Returns a bad status if the log is already shut down.
@@ -150,9 +153,6 @@ class Log : public RefCountedThreadSafe<Log> {
 
   // The closure submitted to allocation_pool_ to allocate a new segment.
   void SegmentAllocationTask();
-
-  // Syncs all state and closes the log.
-  Status Close();
 
   // Return true if there is any on-disk data for the given tablet.
   static bool HasOnDiskData(FsManager* fs_manager, const std::string& tablet_id);

--- a/src/kudu/tserver/simple_tablet_manager.cc
+++ b/src/kudu/tserver/simple_tablet_manager.cc
@@ -120,6 +120,13 @@ TSTabletManager::TSTabletManager(TabletServer* server)
 }
 
 TSTabletManager::~TSTabletManager() {
+  // Close cannot be called from the destructor any more.
+  // as Close from Log::~Log will call the base class Close()
+  // Another way to think about it is that Init and Close go in
+  // pairs. If Init is called virtual, Close should also be
+  if (log_) {
+    WARN_NOT_OK(log_->Close(), "Error closing Log");
+  }
 }
 
 Status TSTabletManager::Load(FsManager *fs_manager) {


### PR DESCRIPTION
Summary: This allows us to weed out inadvertent call of
any kudu style Log functions by setting FLAGS_raft_derived_log=true
from fbcode. This is critical to make sure we are not accessing
Segment related code in BinlogWrapper mode

Test Plan: Tested it using tp2_use_local with setup master
and setup slave with setup_simple_ring.sh. Then uninstalled
the plugin successfully.

Without this fix, the plugin would crash on uninstall with an assert
because Log::Close would be called.

Reviewers: iRitwik, abhinav04sharma, bhatvinay

Subscribers:

Tasks:

Tags: