### PR TITLE
Adding a function to open all index chunks on startup

### DIFF
--- a/src/kudu/consensus/log_index.h
+++ b/src/kudu/consensus/log_index.h
@@ -28,6 +28,7 @@
 #include "kudu/util/status.h"
 
 namespace kudu {
+class Env;
 namespace log {
 
 // An entry in the index.
@@ -73,11 +74,16 @@ class LogIndex : public RefCountedThreadSafe<LogIndex> {
   // earlier entries.
   void GC(int64_t min_index_to_retain);
 
+  Status OpenAllChunksOnStartup(Env *env);
+
  private:
   friend class RefCountedThreadSafe<LogIndex>;
   ~LogIndex();
 
   class IndexChunk;
+
+  Status OpenAndInsertChunk(int64_t chunk_idx,
+      scoped_refptr<IndexChunk>* chunk);
 
   // Open the on-disk chunk with the given index.
   // Note: 'chunk_idx' is the index of the index chunk, not the index of a log _entry_.

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -977,29 +977,6 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   DISALLOW_COPY_AND_ASSIGN(RaftConsensus);
 };
 
-// After completing bootstrap, some of the results need to be plumbed through
-// into the consensus implementation.
-struct ConsensusBootstrapInfo {
-  ConsensusBootstrapInfo();
-  ~ConsensusBootstrapInfo();
-
-  // The id of the last operation in the log
-  OpId last_id;
-
-  // The id of the last committed operation in the log.
-  OpId last_committed_id;
-
-  // REPLICATE messages which were in the log with no accompanying
-  // COMMIT. These need to be passed along to consensus init in order
-  // to potentially commit them.
-  //
-  // These are owned by the ConsensusBootstrapInfo instance.
-  std::vector<ReplicateMsg*> orphaned_replicates;
-
- private:
-  DISALLOW_COPY_AND_ASSIGN(ConsensusBootstrapInfo);
-};
-
 // Handler for consensus rounds.
 // An implementation of this handler must be registered prior to consensus
 // start, and is used to:

--- a/src/kudu/tserver/simple_tablet_manager.cc
+++ b/src/kudu/tserver/simple_tablet_manager.cc
@@ -318,6 +318,12 @@ Status TSTabletManager::Start() {
   Status s = cmeta_manager_->Load(kSysCatalogTabletId, &cmeta);
 
   consensus::ConsensusBootstrapInfo bootstrap_info;
+  // Abstracted logs are supposed to do the log recovery
+  // during Log::Init virtual call. Pass that info to
+  // RaftConsensus::Start now.
+  if (server_->opts().log_factory) {
+    log_->GetRecoveryInfo(&bootstrap_info);
+  }
 
   TRACE("Starting consensus");
   VLOG(2) << "T " << kSysCatalogTabletId << " P " << consensus_->peer_uuid() << ": Peer starting";


### PR DESCRIPTION
Summary: During recovery we first open all index chunks.
Then we use the index to guide our walk through binlog files
to find locally replicated and globally committed ones. The
difference being the pending replicates.

Also adding a function for the bootstrap code during
RaftConsensus::Start to get bootstrap info from plugin

Test Plan: This diff was central to make instances start properly
as slaves in mysqld

Reviewers: iRitwik, abhinav04sharma

Subscribers:

Tasks:

Tags: