### PR TITLE
Adding a leader detected callback which fires when a follower joins t…

### DIFF
--- a/src/kudu/tserver/simple_tablet_manager.cc
+++ b/src/kudu/tserver/simple_tablet_manager.cc
@@ -379,6 +379,9 @@ Status TSTabletManager::SetupRaft() {
   if (server_->opts().norcb) {
     consensus_->SetNoOpReceivedCallback(server_->opts().norcb);
   }
+  if (server_->opts().ldcb) {
+    consensus_->SetLeaderDetectedCallback(server_->opts().ldcb);
+  }
   if (server_->opts().disable_noop) {
     consensus_->DisableNoOpEntries();
   }

--- a/src/kudu/tserver/tablet_server_options.h
+++ b/src/kudu/tserver/tablet_server_options.h
@@ -50,9 +50,18 @@ struct TabletServerOptions : public kudu::server::ServerBaseOptions {
 
   kudu::consensus::ConsensusRoundHandler *round_handler = nullptr;
 
+  // Election Decision Callback
   std::function<void(const consensus::ElectionResult&)> edcb;
+
+  // Term Advancement Callback
   std::function<void(int64_t)> tacb;
+
+  // No-OP received Callback
   std::function<void(const consensus::OpId id)> norcb;
+
+  // Leader Detected Callback. This should eventually be reconciled
+  // with NORCB.
+  std::function<void()> ldcb;
   bool disable_noop = false;
 
   bool IsDistributed() const;


### PR DESCRIPTION
…he ring

Summary: with no term change or no no-op received. We keep track if we
also receive a no-op. And only in the case that norcb has not already
been fired, we fire ldcb. We could fire LDCB all the time, but we need
to reconcile on mysql side if there needs to be 2 callbacks or 1 in
future.

Test Plan: Used this to change MASTER TO and start Slave applier on a
follower restart

Reviewers: iRitwik, abhinav04sharma

Subscribers:

Tasks:

Tags: