### PR TITLE
Maintain ABI compatibility between release and debug builds

### DIFF
--- a/src/kudu/gutil/ref_counted.cc
+++ b/src/kudu/gutil/ref_counted.cc
@@ -15,14 +15,14 @@ namespace subtle {
 
 RefCountedBase::RefCountedBase()
     : ref_count_(0)
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
     , in_dtor_(false)
 #endif
     {
 }
 
 RefCountedBase::~RefCountedBase() {
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   DCHECK(in_dtor_) << "RefCounted object deleted without calling Release()";
 #endif
 }
@@ -31,7 +31,7 @@ void RefCountedBase::AddRef() const {
   // TODO(maruel): Add back once it doesn't assert 500 times/sec.
   // Current thread books the critical section "AddRelease" without release it.
   // DFAKE_SCOPED_LOCK_THREAD_LOCKED(add_release_);
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   DCHECK(!in_dtor_);
 #endif
   ++ref_count_;
@@ -41,11 +41,11 @@ bool RefCountedBase::Release() const {
   // TODO(maruel): Add back once it doesn't assert 500 times/sec.
   // Current thread books the critical section "AddRelease" without release it.
   // DFAKE_SCOPED_LOCK_THREAD_LOCKED(add_release_);
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   DCHECK(!in_dtor_);
 #endif
   if (--ref_count_ == 0) {
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
     in_dtor_ = true;
 #endif
     return true;
@@ -59,32 +59,32 @@ bool RefCountedThreadSafeBase::HasOneRef() const {
 }
 
 RefCountedThreadSafeBase::RefCountedThreadSafeBase() : ref_count_(0) {
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   in_dtor_ = false;
 #endif
 }
 
 RefCountedThreadSafeBase::~RefCountedThreadSafeBase() {
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   DCHECK(in_dtor_) << "RefCountedThreadSafe object deleted without "
                       "calling Release()";
 #endif
 }
 
 void RefCountedThreadSafeBase::AddRef() const {
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   DCHECK(!in_dtor_);
 #endif
   base::RefCountInc(&ref_count_);
 }
 
 bool RefCountedThreadSafeBase::Release() const {
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   DCHECK(!in_dtor_);
   DCHECK(!base::RefCountIsZero(&ref_count_));
 #endif
   if (!base::RefCountDec(&ref_count_)) {
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
     in_dtor_ = true;
 #endif
     return true;

--- a/src/kudu/gutil/ref_counted.h
+++ b/src/kudu/gutil/ref_counted.h
@@ -33,7 +33,7 @@ class RefCountedBase {
 
  private:
   mutable int ref_count_;
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   mutable bool in_dtor_;
 #endif
 
@@ -57,7 +57,7 @@ class RefCountedThreadSafeBase {
 
  private:
   mutable AtomicRefCount ref_count_;
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   mutable bool in_dtor_;
 #endif
 

--- a/src/kudu/gutil/threading/thread_collision_warner.h
+++ b/src/kudu/gutil/threading/thread_collision_warner.h
@@ -101,7 +101,7 @@
 // };
 
 
-#if !defined(NDEBUG)
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
 
 // Defines a class member that acts like a mutex. It is used only as a
 // verification tool.

--- a/src/kudu/util/condition_variable.cc
+++ b/src/kudu/util/condition_variable.cc
@@ -21,7 +21,7 @@ namespace kudu {
 
 ConditionVariable::ConditionVariable(Mutex* user_lock)
     : user_mutex_(&user_lock->native_handle_)
-#if !defined(NDEBUG)
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
     , user_lock_(user_lock)
 #endif
 {
@@ -49,12 +49,12 @@ ConditionVariable::~ConditionVariable() {
 
 void ConditionVariable::Wait() const {
   ThreadRestrictions::AssertWaitAllowed();
-#if !defined(NDEBUG)
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   user_lock_->CheckHeldAndUnmark();
 #endif
   int rv = pthread_cond_wait(&condition_, user_mutex_);
   DCHECK_EQ(0, rv);
-#if !defined(NDEBUG)
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   user_lock_->CheckUnheldAndMark();
 #endif
 }
@@ -68,7 +68,7 @@ bool ConditionVariable::WaitUntil(const MonoTime& until) const {
     return false;
   }
 
-#if !defined(NDEBUG)
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   user_lock_->CheckHeldAndUnmark();
 #endif
 
@@ -89,7 +89,7 @@ bool ConditionVariable::WaitUntil(const MonoTime& until) const {
   DCHECK(rv == 0 || rv == ETIMEDOUT)
     << "unexpected pthread_cond_timedwait return value: " << rv;
 
-#if !defined(NDEBUG)
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   user_lock_->CheckUnheldAndMark();
 #endif
   return rv == 0;
@@ -104,7 +104,7 @@ bool ConditionVariable::WaitFor(const MonoDelta& delta) const {
     return false;
   }
 
-#if !defined(NDEBUG)
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   user_lock_->CheckHeldAndUnmark();
 #endif
 
@@ -123,7 +123,7 @@ bool ConditionVariable::WaitFor(const MonoDelta& delta) const {
 
   DCHECK(rv == 0 || rv == ETIMEDOUT)
     << "unexpected pthread_cond_timedwait return value: " << rv;
-#if !defined(NDEBUG)
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   user_lock_->CheckUnheldAndMark();
 #endif
   return rv == 0;

--- a/src/kudu/util/condition_variable.h
+++ b/src/kudu/util/condition_variable.h
@@ -106,7 +106,7 @@ class ConditionVariable {
   mutable pthread_cond_t condition_;
   pthread_mutex_t* user_mutex_;
 
-#if !defined(NDEBUG)
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   Mutex* user_lock_;     // Needed to adjust shadow lock state on wait.
 #endif
 

--- a/src/kudu/util/mutex.cc
+++ b/src/kudu/util/mutex.cc
@@ -40,7 +40,7 @@ using std::string;
 using strings::Substitute;
 using strings::SubstituteAndAppend;
 
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
 DEFINE_bool(debug_mutex_collect_stacktrace, false,
             "Whether to collect a stacktrace on Mutex contention in a DEBUG build");
 TAG_FLAG(debug_mutex_collect_stacktrace, advanced);
@@ -50,12 +50,12 @@ TAG_FLAG(debug_mutex_collect_stacktrace, hidden);
 namespace kudu {
 
 Mutex::Mutex()
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   : owning_tid_(0),
     stack_trace_(new StackTrace())
 #endif
 {
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   // In debug, setup attributes for lock error checking.
   pthread_mutexattr_t mta;
   int rv = pthread_mutexattr_init(&mta);
@@ -79,7 +79,7 @@ Mutex::~Mutex() {
 
 bool Mutex::TryAcquire() {
   int rv = pthread_mutex_trylock(&native_handle_);
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   DCHECK(rv == 0 || rv == EBUSY) << ". " << strerror(rv) << ". " << GetOwnerThreadInfo();
   if (rv == 0) {
     CheckUnheldAndMark();
@@ -104,7 +104,7 @@ void Mutex::Acquire() {
   MicrosecondsInt64 start_time = GetMonoTimeMicros();
   int rv = pthread_mutex_lock(&native_handle_);
   DCHECK_EQ(0, rv) << ". " << strerror(rv)
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
                    << ". " << GetOwnerThreadInfo()
 #endif
   ; // NOLINT(whitespace/semicolon)
@@ -115,20 +115,20 @@ void Mutex::Acquire() {
     TRACE_COUNTER_INCREMENT("mutex_wait_us", wait_time);
   }
 
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   CheckUnheldAndMark();
 #endif
 }
 
 void Mutex::Release() {
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   CheckHeldAndUnmark();
 #endif
   int rv = pthread_mutex_unlock(&native_handle_);
   DCHECK_EQ(0, rv) << ". " << strerror(rv);
 }
 
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
 void Mutex::AssertAcquired() const {
   DCHECK_EQ(Env::Default()->gettid(), owning_tid_);
 }

--- a/src/kudu/util/mutex.h
+++ b/src/kudu/util/mutex.h
@@ -50,7 +50,7 @@ class Mutex {
   void unlock() { Release(); }
   bool try_lock() { return TryAcquire(); }
 
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   void AssertAcquired() const;
 #else
   void AssertAcquired() const {}
@@ -61,7 +61,7 @@ class Mutex {
 
   pthread_mutex_t native_handle_;
 
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   // Members and routines taking care of locks assertions.
   void CheckHeldAndUnmark();
   void CheckUnheldAndMark();

--- a/src/kudu/util/rw_mutex.cc
+++ b/src/kudu/util/rw_mutex.cc
@@ -41,7 +41,7 @@ void unlock_rwlock(pthread_rwlock_t* rwlock) {
 namespace kudu {
 
 RWMutex::RWMutex()
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
     : writer_tid_(0)
 #endif
 {
@@ -49,7 +49,7 @@ RWMutex::RWMutex()
 }
 
 RWMutex::RWMutex(Priority prio)
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
     : writer_tid_(0)
 #endif
 {
@@ -138,7 +138,7 @@ bool RWMutex::TryWriteLock() {
   return true;
 }
 
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
 
 void RWMutex::AssertAcquired() const {
   lock_guard<simple_spinlock> l(tid_lock_);

--- a/src/kudu/util/rw_mutex.h
+++ b/src/kudu/util/rw_mutex.h
@@ -64,7 +64,7 @@ class RWMutex {
   void WriteUnlock();
   bool TryWriteLock();
 
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   void AssertAcquired() const;
   void AssertAcquiredForReading() const;
   void AssertAcquiredForWriting() const;
@@ -90,7 +90,7 @@ class RWMutex {
     READER,
     WRITER,
   };
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   void CheckLockState(LockState state) const;
   void MarkForReading();
   void MarkForWriting();
@@ -106,7 +106,7 @@ class RWMutex {
 
   pthread_rwlock_t native_handle_;
 
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   // Protects reader_tids_ and writer_tid_.
   mutable simple_spinlock tid_lock_;
 

--- a/src/kudu/util/rw_semaphore.h
+++ b/src/kudu/util/rw_semaphore.h
@@ -137,7 +137,7 @@ class rw_semaphore {
 
     WaitPendingReaders();
 
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
     writer_tid_ = Thread::CurrentThreadId();
 #endif // NDEBUG
     RecordLockHolderStack();
@@ -147,7 +147,7 @@ class rw_semaphore {
     // I expect to be the only writer
     DCHECK_EQ(base::subtle::NoBarrier_Load(&state_), kWriteFlag);
 
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
     writer_tid_ = -1; // Invalid tid.
 #endif // NDEBUG
 
@@ -197,7 +197,7 @@ class rw_semaphore {
 
  private:
   volatile Atomic32 state_;
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   int64_t writer_tid_;
 #endif // NDEBUG
 };

--- a/src/kudu/util/rwc_lock.h
+++ b/src/kudu/util/rwc_lock.h
@@ -128,7 +128,7 @@ class RWCLock {
   int reader_count_;
   bool write_locked_;
 
-#ifndef NDEBUG
+#ifdef FB_DO_NOT_REMOVE  // #ifndef NDEBUG
   static const int kBacktraceBufSize = 1024;
   int64_t writer_tid_;
   int64_t last_writelock_acquire_time_;


### PR DESCRIPTION
Summary: Because the integrations we are currently developing don't
maintain a well defined public API boundary with Kudu, adding fields to
structs in debug mode is unfortunately dangerous and crash prone. At
least for now, we need the ability to build Kudu in release mode and run
linked modules (Raft callbacks, etc) in debug mode. Those modules may
end up #including all kinds of headers (locks, etc) and
difficult-to-understand runtime crashes are the result.

In a perfect world, we would define an ABI-compatible interface inside
of KuduRaft and prevent exposing details of the locks we are using
inside of Log, RaftConsensus, etc. In the current world, we want the
flexibility to hack through and get something working quickly without
having to build in release mode only.

This patch disables several debug-mode-only features in Kudu (keeping
track of mutex owners, etc) because they end up changing the structs
defined in commonly-used header files. This fixes some crashes we've
been seeing when integrating some plugin code.

Test Plan: I ran a gtest that reliably reproduced a nasty crash and now
it doesn't crash anymore.

Reviewers: anirbanr-fb, abhinav04sharma