### PR TITLE
Rename or hide some global symbols with common names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1431,7 +1431,7 @@ if (UNIX)
       WORKING_DIRECTORY ${DOXY_CLIENT_DESTDIR}/${CMAKE_INSTALL_PREFIX}
       COMMENT "Generating Kudu C++ client API documentation"
     )
-    add_dependencies(doxy_install_client_alt_destdir kudu_client_exported)
+    #add_dependencies(doxy_install_client_alt_destdir kudu_client_exported)
     add_dependencies(doxygen doxy_install_client_alt_destdir)
     # If doxygen is present, generate doxygen documentation along with 'docs'.
     add_dependencies(docs doxygen)

--- a/src/kudu/fs/log_block_manager-test-util.cc
+++ b/src/kudu/fs/log_block_manager-test-util.cc
@@ -329,10 +329,10 @@ Status LBMCorruptor::AddMisalignedBlockToContainer() {
   uint64_t block_length = rand_.Uniform(fs_block_size * 4);
   block_length -= block_length % sizeof(raw_block_id);
   uint8_t data[block_length];
-  for (int i = 0; i < ARRAYSIZE(data); i += sizeof(raw_block_id)) {
+  for (int i = 0; i < KUDU_ARRAYSIZE(data); i += sizeof(raw_block_id)) {
     memcpy(&data[i], &raw_block_id, sizeof(raw_block_id));
   }
-  RETURN_NOT_OK(data_file->Write(block_offset, Slice(data, ARRAYSIZE(data))));
+  RETURN_NOT_OK(data_file->Write(block_offset, Slice(data, KUDU_ARRAYSIZE(data))));
   RETURN_NOT_OK(data_file->Close());
 
   // Having written out the block, write a corresponding metadata record.

--- a/src/kudu/gutil/macros.h
+++ b/src/kudu/gutil/macros.h
@@ -24,7 +24,7 @@
 // expression is true. For example, you could use it to verify the
 // size of a static array:
 //
-//   COMPILE_ASSERT(ARRAYSIZE(content_type_names) == CONTENT_NUM_TYPES,
+//   COMPILE_ASSERT(KUDU_ARRAYSIZE(content_type_names) == CONTENT_NUM_TYPES,
 //                  content_type_names_incorrect_size);
 //
 // or to make sure a struct is smaller than a certain size:
@@ -120,7 +120,7 @@ struct CompileAssert {
 //
 // One caveat is that, for C++03, arraysize() doesn't accept any array of
 // an anonymous type or a type defined inside a function.  In these rare
-// cases, you have to use the unsafe ARRAYSIZE() macro below.  This is
+// cases, you have to use the unsafe KUDU_ARRAYSIZE() macro below.  This is
 // due to a limitation in C++03's template system.  The limitation has
 // been removed in C++11.
 
@@ -140,26 +140,26 @@ char (&ArraySizeHelper(const T (&array)[N]))[N];
 
 #define arraysize(array) (sizeof(ArraySizeHelper(array)))
 
-// ARRAYSIZE performs essentially the same calculation as arraysize,
+// KUDU_ARRAYSIZE performs essentially the same calculation as arraysize,
 // but can be used on anonymous types or types defined inside
 // functions.  It's less safe than arraysize as it accepts some
 // (although not all) pointers.  Therefore, you should use arraysize
 // whenever possible.
 //
-// The expression ARRAYSIZE(a) is a compile-time constant of type
+// The expression KUDU_ARRAYSIZE(a) is a compile-time constant of type
 // size_t.
 //
-// ARRAYSIZE catches a few type errors.  If you see a compiler error
+// KUDU_ARRAYSIZE catches a few type errors.  If you see a compiler error
 //
 //   "warning: division by zero in ..."
 //
-// when using ARRAYSIZE, you are (wrongfully) giving it a pointer.
-// You should only use ARRAYSIZE on statically allocated arrays.
+// when using KUDU_ARRAYSIZE, you are (wrongfully) giving it a pointer.
+// You should only use KUDU_ARRAYSIZE on statically allocated arrays.
 //
 // The following comments are on the implementation details, and can
 // be ignored by the users.
 //
-// ARRAYSIZE(arr) works by inspecting sizeof(arr) (the # of bytes in
+// KUDU_ARRAYSIZE(arr) works by inspecting sizeof(arr) (the # of bytes in
 // the array) and sizeof(*(arr)) (the # of bytes in one array
 // element).  If the former is divisible by the latter, perhaps arr is
 // indeed an array, in which case the division result is the # of
@@ -181,9 +181,9 @@ char (&ArraySizeHelper(const T (&array)[N]))[N];
 //
 // - wan 2005-11-16
 //
-// Starting with Visual C++ 2005, WinNT.h includes ARRAYSIZE.
+// Starting with Visual C++ 2005, WinNT.h includes KUDU_ARRAYSIZE.
 #if !defined(_MSC_VER) || (defined(_MSC_VER) && _MSC_VER < 1400)
-#define ARRAYSIZE(a) \
+#define KUDU_ARRAYSIZE(a) \
   ((sizeof(a) / sizeof(*(a))) / \
    static_cast<size_t>(!(sizeof(a) % sizeof(*(a)))))
 #endif

--- a/src/kudu/gutil/once.cc
+++ b/src/kudu/gutil/once.cc
@@ -37,7 +37,7 @@ void GoogleOnceInternalInit(Atomic32 *control, void (*func)(),
   // Short circuit the simplest case to avoid procedure call overhead.
   if (base::subtle::Acquire_CompareAndSwap(control, GOOGLE_ONCE_INTERNAL_INIT,
           GOOGLE_ONCE_INTERNAL_RUNNING) == GOOGLE_ONCE_INTERNAL_INIT ||
-      base::internal::SpinLockWait(control, ARRAYSIZE(trans), trans) ==
+      base::internal::SpinLockWait(control, KUDU_ARRAYSIZE(trans), trans) ==
       GOOGLE_ONCE_INTERNAL_INIT) {
     if (func != nullptr) {
       (*func)();

--- a/src/kudu/gutil/strings/human_readable.cc
+++ b/src/kudu/gutil/strings/human_readable.cc
@@ -407,7 +407,7 @@ bool HumanReadableElapsedTime::ToDouble(const string& str, double* value) {
     }
     unit_start = SkipLeadingWhiteSpace(unit_start);
     bool found_unit = false;
-    for (int i = 0; !found_unit && i < ARRAYSIZE(kUnits); ++i) {
+    for (int i = 0; !found_unit && i < KUDU_ARRAYSIZE(kUnits); ++i) {
       const size_t unit_len = strlen(kUnits[i].unit);
       if (strncmp(unit_start, kUnits[i].unit, unit_len) == 0) {
         work_value += factor * kUnits[i].seconds;

--- a/src/kudu/server/server_base.cc
+++ b/src/kudu/server/server_base.cc
@@ -418,6 +418,22 @@ Sockaddr ServerBase::first_http_address() const {
 }
 #endif
 
+const security::TlsContext& ServerBase::tls_context() const {
+  return messenger_->tls_context();
+}
+
+security::TlsContext* ServerBase::mutable_tls_context() {
+  return messenger_->mutable_tls_context();
+}
+
+const security::TokenVerifier& ServerBase::token_verifier() const {
+  return messenger_->token_verifier();
+}
+
+security::TokenVerifier* ServerBase::mutable_token_verifier() {
+  return messenger_->mutable_token_verifier();
+}
+
 const NodeInstancePB& ServerBase::instance_pb() const {
   return *DCHECK_NOTNULL(instance_pb_.get());
 }

--- a/src/kudu/server/server_base.h
+++ b/src/kudu/server/server_base.h
@@ -24,7 +24,6 @@
 #include "kudu/gutil/gscoped_ptr.h"
 #include "kudu/gutil/macros.h"
 #include "kudu/gutil/ref_counted.h"
-#include "kudu/rpc/messenger.h"
 #include "kudu/security/simple_acl.h"
 #include "kudu/server/server_base_options.h"
 #include "kudu/util/countdown_latch.h"
@@ -53,6 +52,7 @@ class Clock;
 } // namespace clock
 
 namespace rpc {
+class Messenger;
 class ResultTracker;
 class RpcContext;
 class ServiceIf;
@@ -92,11 +92,11 @@ class ServerBase {
 
   FsManager* fs_manager() { return fs_manager_.get(); }
 
-  const security::TlsContext& tls_context() const { return messenger_->tls_context(); }
-  security::TlsContext* mutable_tls_context() { return messenger_->mutable_tls_context(); }
+  const security::TlsContext& tls_context() const;
+  security::TlsContext* mutable_tls_context();
 
-  const security::TokenVerifier& token_verifier() const { return messenger_->token_verifier(); }
-  security::TokenVerifier* mutable_token_verifier() { return messenger_->mutable_token_verifier(); }
+  const security::TokenVerifier& token_verifier() const;
+  security::TokenVerifier* mutable_token_verifier();
 
   // Return the instance identifier of this server.
   // This may not be called until after the server is Started.

--- a/src/kudu/tools/rebalance_algo-test.cc
+++ b/src/kudu/tools/rebalance_algo-test.cc
@@ -47,7 +47,7 @@ struct TestClusterConfig;
 
 #define VERIFY_MOVES(test_config) \
   do { \
-    for (auto idx = 0; idx < ARRAYSIZE((test_config)); ++idx) { \
+    for (auto idx = 0; idx < KUDU_ARRAYSIZE((test_config)); ++idx) { \
       SCOPED_TRACE(Substitute("test config index: $0", idx)); \
       NO_FATALS(VerifyRebalancingMoves((test_config)[idx])); \
     } \

--- a/src/kudu/util/flag_validators-test.cc
+++ b/src/kudu/util/flag_validators-test.cc
@@ -115,7 +115,7 @@ class FlagsValidatorsDeathTest : public KuduTest {
 
 TEST_F(FlagsValidatorsDeathTest, GroupedSuccessNoFlags) {
   const char* argv[] = { "argv_set_0" };
-  NO_FATALS(RunSuccess(argv, ARRAYSIZE(argv)));
+  NO_FATALS(RunSuccess(argv, KUDU_ARRAYSIZE(argv)));
 }
 
 TEST_F(FlagsValidatorsDeathTest, GroupedSuccessSimple) {


### PR DESCRIPTION
This stack hides a couple of global symbols (ARRAYNAME and the libev constants like EV_READ) to prevent them from conflicting with other libraries (such as libevent) in the same compilation unit. See the individual commits in this stack for more information. I also snuck in a small build change that is unrelated to the symbol issues but makes it possible to build kuduraft in debug mode (cmake ../..).