### PR TITLE
When we are doing a first run, assumption is we are creating a fresh …

### DIFF
--- a/src/kudu/tserver/simple_tablet_manager.h
+++ b/src/kudu/tserver/simple_tablet_manager.h
@@ -88,7 +88,11 @@ class TSTabletManager : public consensus::ConsensusRoundHandler {
   // the bootstrap is performed asynchronously.
   Status Init(bool is_first_run);
 
-  Status Start();
+  // Start the raft ring.
+  // At the end of this consensus has been completed and ring should be up
+  // and running.
+  // In case of is_first_run, some parts of bootstrapping are bypassed
+  Status Start(bool is_first_run);
 
   bool IsInitialized() const;
 

--- a/src/kudu/tserver/tablet_server.cc
+++ b/src/kudu/tserver/tablet_server.cc
@@ -178,7 +178,7 @@ Status TabletServer::Start() {
     return Status::IllegalState("Tablet manager is not initialized");
   }
 
-  RETURN_NOT_OK_PREPEND(tablet_manager_->Start(),
+  RETURN_NOT_OK_PREPEND(tablet_manager_->Start(is_first_run_),
                         "Unable to start raft in tablet manager");
   google::FlushLogFiles(google::INFO); // Flush the startup messages.
   return Status::OK();


### PR DESCRIPTION
…raft instance.

Summary: In that case, the recovery does not have to get the OpIds
from the binlog files. It is also likely that first run has no
opids because we are moving from non-raft to raft mode.

Test Plan: This was done to prevent wrong behavior when we wanted to
create a new raft ring. Log::Init in myshadow would go through all the
previous binlog files and look for Last OpId.

Reviewers: mpercy

Subscribers:

Tasks:

Tags: