### PR TITLE
[1/n] [FlexiRaft] Configuration changes to enable flexi-raft support

### DIFF
--- a/src/kudu/consensus/metadata.proto
+++ b/src/kudu/consensus/metadata.proto
@@ -35,6 +35,13 @@ message RaftPeerAttrsPB {
   // If set to 'true', the replica needs to be replaced regardless of
   // its health report.
   optional bool replace = 2 [ default = false ];
+
+  // Denotes if the server is backed by a database. If not, it only has the
+  // logs.
+  optional bool backing_db_present = 3 [ default = true ];
+
+  // Geographic region of the raft server.
+  optional string region = 4;
 }
 
 // Report on a replica's (peer's) health.


### PR DESCRIPTION
A simple diff to begin the flexiraft changes. It achieves a couple of things.
1. Add a flag to denote if the server is backed by a database.
2. A field for the geographic region of the server 