### PR TITLE
Add a gflag to not canonicalize UUIDs

### DIFF
--- a/src/kudu/server/server_base.cc
+++ b/src/kudu/server/server_base.cc
@@ -468,7 +468,11 @@ Status ServerBase::Init() {
     LOG(INFO) << "Could not load existing FS layout: " << s.ToString();
     LOG(INFO) << "Attempting to create new FS layout instead";
     is_first_run_ = true;
-    s = fs_manager_->CreateInitialFileSystemLayout();
+    boost::optional<std::string> uuid;
+    if (!options_.app_provided_instance_uuid.empty()) {
+      uuid = options_.app_provided_instance_uuid;
+    }
+    s = fs_manager_->CreateInitialFileSystemLayout(uuid);
     if (s.IsAlreadyPresent()) {
       // The operator is likely trying to start up with an extra entry in their
       // `fs_data_dirs` configuration.

--- a/src/kudu/server/server_base_options.h
+++ b/src/kudu/server/server_base_options.h
@@ -47,6 +47,7 @@ struct ServerBaseOptions {
 
   std::string dump_info_path;
   std::string dump_info_format;
+  std::string app_provided_instance_uuid;
 
   int32_t metrics_log_interval_ms;
 

--- a/src/kudu/util/oid_generator.cc
+++ b/src/kudu/util/oid_generator.cc
@@ -23,6 +23,7 @@
 #include <string>
 
 #include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
 
 #include "kudu/gutil/stringprintf.h"
 #include "kudu/gutil/strings/substitute.h"
@@ -31,15 +32,23 @@
 using std::string;
 using strings::Substitute;
 
+DEFINE_bool(cononicalize_uuid, true,
+            "If set this strips -/dashes from all uuids and makes "
+            "it a 16 character string at generation time.");
+
 namespace kudu {
 
 namespace {
 
 string ConvertUuidToString(const boost::uuids::uuid& to_convert) {
-  const uint8_t* uuid = to_convert.data;
-  return StringPrintf("%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
-               uuid[0], uuid[1], uuid[2], uuid[3], uuid[4], uuid[5], uuid[6], uuid[7],
-               uuid[8], uuid[9], uuid[10], uuid[11], uuid[12], uuid[13], uuid[14], uuid[15]);
+  if (FLAGS_cononicalize_uuid) {
+    const uint8_t* uuid = to_convert.data;
+    return StringPrintf("%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
+                 uuid[0], uuid[1], uuid[2], uuid[3], uuid[4], uuid[5], uuid[6], uuid[7],
+                 uuid[8], uuid[9], uuid[10], uuid[11], uuid[12], uuid[13], uuid[14], uuid[15]);
+  } else {
+    return boost::uuids::to_string(to_convert);
+  }
 }
 
 } // anonymous namespace


### PR DESCRIPTION
Summary: thie enables compatibility with UUIDs from mysql

Test Plan: Enhanced the unit test to toggle the gflag

Reviewers:

Subscribers:

Tasks:

Tags: