### PR TITLE
Master Ban support

### DIFF
--- a/src/kudu/consensus/consensus_queue.h
+++ b/src/kudu/consensus/consensus_queue.h
@@ -372,7 +372,8 @@ class PeerMessageQueue {
   // boost::none, the queue will notify its observers when 'successor_uuid' is
   // caught up to the leader. Otherwise, it will notify its observers
   // with the UUID of the first voter that is caught up.
-  void BeginWatchForSuccessor(const boost::optional<std::string>& successor_uuid);
+  void BeginWatchForSuccessor(const boost::optional<std::string>& successor_uuid,
+      const std::function<bool(const kudu::consensus::RaftPeerPB&)>& filter_fn);
   void EndWatchForSuccessor();
 
  private:
@@ -572,6 +573,7 @@ class PeerMessageQueue {
   bool successor_watch_in_progress_;
   boost::optional<std::string> designated_successor_uuid_;
 
+  std::function<bool(const kudu::consensus::RaftPeerPB&)> tl_filter_fn_;
   // We assume that we never have multiple threads racing to append to the queue.
   // This fake mutex adds some extra assurance that this implementation property
   // doesn't change.

--- a/src/kudu/consensus/quorum_util.cc
+++ b/src/kudu/consensus/quorum_util.cc
@@ -68,6 +68,18 @@ bool IsRaftConfigVoter(const std::string& uuid, const RaftConfigPB& config) {
   return false;
 }
 
+bool GetRaftConfigMemberRegion(const std::string& uuid,
+    const RaftConfigPB& config, bool *is_voter, std::string *region) {
+  for (const RaftPeerPB& peer : config.peers()) {
+    if (peer.permanent_uuid() == uuid) {
+      *is_voter = (peer.member_type() == RaftPeerPB::VOTER);
+      *region = peer.attrs().region();
+      return true;
+    }
+  }
+  return false;
+}
+
 bool IsVoterRole(RaftPeerPB::Role role) {
   return role == RaftPeerPB::LEADER || role == RaftPeerPB::FOLLOWER;
 }

--- a/src/kudu/consensus/quorum_util.h
+++ b/src/kudu/consensus/quorum_util.h
@@ -47,6 +47,8 @@ enum class MajorityHealthPolicy {
 
 bool IsRaftConfigMember(const std::string& uuid, const RaftConfigPB& config);
 bool IsRaftConfigVoter(const std::string& uuid, const RaftConfigPB& config);
+bool GetRaftConfigMemberRegion(const std::string& uuid, const RaftConfigPB& config,
+    bool *is_voter, std::string *region);
 
 // Whether the specified Raft role is attributed to a peer which can participate
 // in leader elections.

--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -92,6 +92,11 @@ DEFINE_double(leader_failure_max_missed_heartbeat_periods, 3.0,
              "The value passed to this flag may be fractional.");
 TAG_FLAG(leader_failure_max_missed_heartbeat_periods, advanced);
 
+DEFINE_double(snooze_for_leader_ban_ratio, 1.0,
+             "Failure detector for this instance should be at a higher ratio than other instances"
+             ". This will prevent this instance from initiating an election");
+TAG_FLAG(snooze_for_leader_ban_ratio, advanced);
+
 DEFINE_int32(leader_failure_exp_backoff_max_delta_ms, 20 * 1000,
              "Maximum time to sleep in between leader election retries, in addition to the "
              "regular timeout. When leader election fails the interval in between retries "
@@ -593,7 +598,8 @@ Status RaftConsensus::StepDown(LeaderStepDownResponsePB* resp) {
 }
 
 Status RaftConsensus::TransferLeadership(const boost::optional<string>& new_leader_uuid,
-                                         LeaderStepDownResponsePB* resp) {
+    const std::function<bool(const kudu::consensus::RaftPeerPB&)>& filter_fn,
+    LeaderStepDownResponsePB* resp) {
   TRACE_EVENT0("consensus", "RaftConsensus::TransferLeadership");
   ThreadRestrictions::AssertWaitAllowed();
   LockGuard l(lock_);
@@ -626,11 +632,12 @@ Status RaftConsensus::TransferLeadership(const boost::optional<string>& new_lead
       return Status::InvalidArgument(msg);
     }
   }
-  return BeginLeaderTransferPeriodUnlocked(new_leader_uuid);
+  return BeginLeaderTransferPeriodUnlocked(new_leader_uuid, filter_fn);
 }
 
 Status RaftConsensus::BeginLeaderTransferPeriodUnlocked(
-    const boost::optional<string>& successor_uuid) {
+    const boost::optional<string>& successor_uuid,
+    const std::function<bool(const kudu::consensus::RaftPeerPB&)>& filter_fn) {
   DCHECK(lock_.is_locked());
   if (leader_transfer_in_progress_.CompareAndSwap(false, true)) {
     return Status::ServiceUnavailable(
@@ -638,7 +645,7 @@ Status RaftConsensus::BeginLeaderTransferPeriodUnlocked(
                    options_.tablet_id));
   }
   leader_transfer_in_progress_.Store(true, kMemOrderAcquire);
-  queue_->BeginWatchForSuccessor(successor_uuid);
+  queue_->BeginWatchForSuccessor(successor_uuid, filter_fn);
   transfer_period_timer_->Start();
   return Status::OK();
 }
@@ -1449,7 +1456,10 @@ Status RaftConsensus::UpdateReplica(const ConsensusRequestPB* request,
     // Snooze the failure detector as soon as we decide to accept the message.
     // We are guaranteed to be acting as a FOLLOWER at this point by the above
     // sanity check.
-    SnoozeFailureDetector();
+    // If this particular instance is banned from cluster manager,
+    // then we snooze for longer to give other instances an opportunity to win
+    // the election
+    SnoozeFailureDetector(boost::none, MinimumElectionTimeoutWithBan());
 
     last_leader_communication_time_micros_ = GetMonoTimeMicros();
 
@@ -2938,6 +2948,12 @@ void RaftConsensus::SnoozeFailureDetector(boost::optional<string> reason_for_log
 MonoDelta RaftConsensus::MinimumElectionTimeout() const {
   int32_t failure_timeout = FLAGS_leader_failure_max_missed_heartbeat_periods *
       FLAGS_raft_heartbeat_interval_ms;
+  return MonoDelta::FromMilliseconds(failure_timeout);
+}
+
+MonoDelta RaftConsensus::MinimumElectionTimeoutWithBan() const {
+  int32_t failure_timeout = FLAGS_leader_failure_max_missed_heartbeat_periods *
+      FLAGS_raft_heartbeat_interval_ms * FLAGS_snooze_for_leader_ban_ratio;
   return MonoDelta::FromMilliseconds(failure_timeout);
 }
 

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -233,6 +233,7 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   // success.
   // Additional calls to this method during the transfer period prolong it.
   Status TransferLeadership(const boost::optional<std::string>& new_leader_uuid,
+                            const std::function<bool(const kudu::consensus::RaftPeerPB&)>& filter_fn,
                             LeaderStepDownResponsePB* resp);
 
   // Begin or end a leadership transfer period. During a transfer period, a
@@ -240,7 +241,8 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   // followers. If a leader transfer period is already in progress,
   // BeginLeaderTransferPeriodUnlocked returns ServiceUnavailable.
   Status BeginLeaderTransferPeriodUnlocked(
-      const boost::optional<std::string>& successor_uuid);
+      const boost::optional<std::string>& successor_uuid,
+      const std::function<bool(const kudu::consensus::RaftPeerPB&)>& filter_fn);
   void EndLeaderTransferPeriod();
 
   // Creates a new ConsensusRound, the entity that owns all the data
@@ -378,6 +380,9 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   // Return the minimum election timeout. Due to backoff and random
   // jitter, election timeouts may be longer than this.
   MonoDelta MinimumElectionTimeout() const;
+
+  // Return the minimum election timeout considering ban-factor
+  MonoDelta MinimumElectionTimeoutWithBan() const;
 
   // Returns a copy of the state of the consensus system.
   // If 'report_health' is set to 'INCLUDE_HEALTH_REPORT', and if the

--- a/src/kudu/tserver/tablet_server_options.cc
+++ b/src/kudu/tserver/tablet_server_options.cc
@@ -32,12 +32,24 @@
 #include "kudu/tserver/tablet_server.h"
 #include "kudu/util/flag_tags.h"
 #include "kudu/util/status.h"
+#include <boost/algorithm/string.hpp>
 
+// TODO - iRitwik ( please refine these mechanisms to a standard way of
+// passing all the properties of an instance )
 DEFINE_string(tserver_addresses, "",
               "Comma-separated list of the RPC addresses belonging to all "
               "instances in this cluster. "
               "NOTE: if not specified, configures a non-replicated Master.");
 TAG_FLAG(tserver_addresses, stable);
+
+DEFINE_string(tserver_regions, "",
+              "Comma-separated list of regions which is parallel to tserver_addresses.");
+TAG_FLAG(tserver_regions, stable);
+
+DEFINE_string(tserver_bbd, "",
+              "Comma-separated list of bool strings to specify Backed by "
+              "Database(non-witness). Runs parallel to tserver_addresses.");
+TAG_FLAG(tserver_bbd, stable);
 
 namespace kudu {
 namespace tserver {
@@ -67,6 +79,32 @@ TabletServerOptions::TabletServerOptions() {
       LOG(WARNING) << "Only 2 tservers are specified by tserver_addresses_flag ('" <<
           FLAGS_tserver_addresses << "'), but minimum of 3 are required to tolerate failures"
           " of any one tserver. It is recommended to use at least 3 tservers.";
+    }
+  }
+
+  if (!FLAGS_tserver_regions.empty()) {
+    boost::split(tserver_regions, FLAGS_tserver_regions, boost::is_any_of(","));
+    if (tserver_regions.size() != tserver_addresses.size()) {
+      LOG(FATAL) << "The number of tserver regions has to be same as tservers: "
+          << FLAGS_tserver_regions << " " << FLAGS_tserver_addresses;
+    }
+  }
+  if (!FLAGS_tserver_bbd.empty()) {
+    std::vector<std::string> bbds;
+    boost::split(bbds, FLAGS_tserver_bbd, boost::is_any_of(","));
+    if (bbds.size() != tserver_addresses.size()) {
+      LOG(FATAL) << "The number of tserver bbd tags has to be same as tservers: "
+          << FLAGS_tserver_bbd << " " << FLAGS_tserver_addresses;
+    }
+    for (auto tsbbd: bbds) {
+      if (tsbbd == "true") {
+        tserver_bbd.push_back(true);
+      } else if (tsbbd == "false") {
+        tserver_bbd.push_back(false);
+      } else {
+        LOG(FATAL) << "tserver bbd tags has to be bool true|false : "
+            << FLAGS_tserver_bbd;
+      }
     }
   }
 }

--- a/src/kudu/tserver/tablet_server_options.h
+++ b/src/kudu/tserver/tablet_server_options.h
@@ -45,6 +45,8 @@ struct TabletServerOptions : public kudu::server::ServerBaseOptions {
   TabletServerOptions();
 
   std::vector<HostPort> tserver_addresses;
+  std::vector<std::string> tserver_regions;
+  std::vector<bool> tserver_bbd;
 
   std::shared_ptr<kudu::log::LogFactory> log_factory;
 


### PR DESCRIPTION
Summary:
1. Using a special global variable (to be set from cluster manager)
   which increases the failure timeout for banned regions/instances.

2. Transfer leadership without a designated uuid now supports a filter
function. Using this filter function we can filter out banned instances
or witnesses.

Test Plan: tested on mysql MTR side by running 100s of simulations with
master ban. With a snooze factor of 2.75, banned instances were never
elected. The reason we need 2.75 and not a lower number is 1.25 is
because today kudu's heuristics for failure timeouts create a situation
where the first "fast" request vote typically fails due to withhold
votes window

Reviewers: iRitwik, mpercy

Subscribers:

Tasks:

Tags: