### PR TITLE
Transfer leadership for a designated UUID will transfer immediately if

### DIFF
--- a/src/kudu/consensus/consensus_queue.h
+++ b/src/kudu/consensus/consensus_queue.h
@@ -484,6 +484,17 @@ class PeerMessageQueue {
   void TransferLeadershipIfNeeded(const TrackedPeer& peer,
                                   const ConsensusStatusPB& status);
 
+  // returns true if basic checks to transfer leadership to this peer are OK
+  // current queue should be in leader state and peer must be a VOTER
+  // Also returns a pointer to the RaftPeerPB if successful
+  bool BasicChecksOKToTransferAndGetPeerUnlocked(
+      const TrackedPeer& peer, RaftPeerPB **peer_pb_ptr);
+
+  // If the peer is caught up, notify the peer to start an election
+  // immediately
+  bool PeerTransferLeadershipImmediatelyUnlocked(
+      const std::string& peer_uuid);
+
   // Calculate a peer's up-to-date health status based on internal fields.
   static HealthReportPB::HealthStatus PeerHealthStatus(const TrackedPeer& peer);
 

--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -1676,6 +1676,13 @@ void RaftConsensus::FillConsensusResponseOKUnlocked(ConsensusResponsePB* respons
   DCHECK(lock_.is_locked());
   TRACE("Filling consensus response to leader.");
   response->set_responder_term(CurrentTermUnlocked());
+
+  // if RESPONSE STATUS does not have error - i.e. common case
+  // and there are messages in the request, then last_received_cur_leader_
+  // = last_from_leader
+  // and AppendOperations also uses the same OpId (last_id) to
+  // update queue_state_.last_appended.
+  // So in COMMON case both the first and second OpId's should be the same.
   response->mutable_status()->mutable_last_received()->CopyFrom(
       queue_->GetLastOpIdInLog());
   response->mutable_status()->mutable_last_received_current_leader()->CopyFrom(


### PR DESCRIPTION
fully caught up

Summary: This significantly reduces the wait for the next
ResponseFromPeer. This cuts down average LMP times from ~400 ms
to ~100ms.

Test Plan: Tested it on mysql side using setup_raft and doing
multiple LMPs.
Test 1: no gvar set
LMP avg time = 395ms

Test 2: synchronus_transfer_leadership set
LMP avg time = 76ms

Other tests are being authored using Mysql raft mocking framework,
but they need to wait for full support for all binlog event types

Reviewers: mpercy, iRitwik

Subscribers:

Tasks:

Tags: