### PR TITLE
[consensus] Implement Raft proxying PR 2/n

### DIFF
--- a/src/kudu/consensus/consensus.proto
+++ b/src/kudu/consensus/consensus.proto
@@ -143,6 +143,7 @@ enum OperationType {
   // ALTER_SCHEMA_OP = 4;
   CHANGE_CONFIG_OP = 5;
   WRITE_OP_EXT = 6;
+  PROXY_OP = 7;
 }
 
 /*
@@ -168,6 +169,11 @@ message ChangeConfigRecordPB {
 
   // The new configuration to set the configuration to.
   required RaftConfigPB new_config = 3;
+}
+
+message ProxyRecordPB {
+  // The destination server intended to receive this message.
+  optional bytes dest_server = 1;
 }
 
 enum ChangeConfigType {
@@ -264,6 +270,7 @@ message ReplicateMsg {
   //optional tserver.WriteRequestPB write_request = 5;
   //optional tserver.AlterSchemaRequestPB alter_schema_request = 6;
   optional ChangeConfigRecordPB change_config_record = 7;
+  optional ProxyRecordPB proxy_record = 10;
 
   // The client's request id for this message, if it is set.
   optional rpc.RequestIdPB request_id = 8;
@@ -399,10 +406,18 @@ message ConsensusRequestPB {
   // UUID of server this request is addressed to.
   optional bytes dest_uuid = 7;
 
+  // UUID of server that will proxy this request to the eventual 'dest_uuid'.
+  // Must be set if this request is intended to be proxied.
+  optional bytes proxy_dest_uuid = 12;
+
   required string tablet_id = 1;
 
-  // The uuid of the peer making the call.
+  // UUID of the leader peer making the call.
   required bytes caller_uuid = 2;
+
+  // UUID of server proxying this request.
+  // Must be set if this request was proxied on behalf of the leader.
+  optional bytes proxy_caller_uuid = 13;
 
   // The caller's term. As only leaders can send messages,
   // replicas will accept all messages as long as the term
@@ -649,6 +664,22 @@ message UnsafeChangeConfigResponsePB {
   optional ServerErrorPB error = 1;
 }
 
+message ChangeProxyTopologyRequestPB {
+  // UUID of server this request is addressed to.
+  optional bytes dest_uuid = 1;
+  optional bytes tablet_id = 2;
+
+  // Sender identification, it could be a static string as well.
+  optional bytes caller_id = 3;
+
+  // The new proxy topology to use.
+  optional ProxyTopologyPB new_config = 4;
+}
+
+message ChangeProxyTopologyResponsePB {
+  optional ServerErrorPB error = 1;
+}
+
 // A Raft implementation.
 service ConsensusService {
   option (kudu.rpc.default_authz_method) = "AuthorizeServiceUser";
@@ -673,6 +704,9 @@ service ConsensusService {
 
   // Implements unsafe config change operation for manual recovery use cases.
   rpc UnsafeChangeConfig(UnsafeChangeConfigRequestPB) returns (UnsafeChangeConfigResponsePB);
+
+  // Change the routing graph that defines how requests are proxied.
+  rpc ChangeProxyTopology(ChangeProxyTopologyRequestPB) returns (ChangeProxyTopologyResponsePB);
 
   rpc GetNodeInstance(GetNodeInstanceRequestPB) returns (GetNodeInstanceResponsePB);
 

--- a/src/kudu/consensus/consensus_queue.h
+++ b/src/kudu/consensus/consensus_queue.h
@@ -40,6 +40,7 @@
 #include "kudu/consensus/metadata.pb.h"
 #include "kudu/consensus/opid.pb.h"
 #include "kudu/consensus/ref_counted_replicate.h"
+#include "kudu/consensus/time_manager.h"
 #include "kudu/gutil/gscoped_ptr.h"
 #include "kudu/gutil/ref_counted.h"
 #include "kudu/gutil/threading/thread_collision_warner.h"
@@ -65,7 +66,6 @@ class ConsensusRequestPB;
 class ConsensusResponsePB;
 class ConsensusStatusPB;
 class PeerMessageQueueObserver;
-class TimeManager;
 #ifdef FB_DO_NOT_REMOVE
 class StartTabletCopyRequestPB;
 #endif
@@ -375,6 +375,13 @@ class PeerMessageQueue {
   void BeginWatchForSuccessor(const boost::optional<std::string>& successor_uuid,
       const std::function<bool(const kudu::consensus::RaftPeerPB&)>& filter_fn);
   void EndWatchForSuccessor();
+
+  // TODO(mpercy): It's probably not safe in general to access a queue's log
+  // cache via bare pointer, since (IIRC) a queue will be reconstructed
+  // transitioning to/from leader. Check this.
+  LogCache* log_cache() {
+    return &log_cache_;
+  }
 
  private:
   FRIEND_TEST(ConsensusQueueTest, TestQueueAdvancesCommittedIndex);

--- a/src/kudu/tserver/consensus_service.h
+++ b/src/kudu/tserver/consensus_service.h
@@ -103,6 +103,10 @@ class ConsensusServiceImpl : public consensus::ConsensusServiceIf {
                                   consensus::UnsafeChangeConfigResponsePB* resp,
                                   rpc::RpcContext* context) override;
 
+  virtual void ChangeProxyTopology(const consensus::ChangeProxyTopologyRequestPB* req,
+                                   consensus::ChangeProxyTopologyResponsePB* resp,
+                                   rpc::RpcContext* context) override;
+
   virtual void GetNodeInstance(const consensus::GetNodeInstanceRequestPB* req,
                                consensus::GetNodeInstanceResponsePB* resp,
                                rpc::RpcContext* context) override;


### PR DESCRIPTION
Initial backport of original patch and tests written against the upstream Kudu master branch

This is a second stack in a series after PR #43. Integration tests have been stripped since they are not currently supported in kuduraft.

The following is included in this stack:

Support for actually proxying received messages meant for another node
Support for tracking proxied messages and sending messages through proxies at the leader level