### PR TITLE
[consensus] Implement Raft proxying PR 1/n (#43)

### DIFF
--- a/src/kudu/consensus/CMakeLists.txt
+++ b/src/kudu/consensus/CMakeLists.txt
@@ -117,6 +117,7 @@ set(CONSENSUS_SRCS
   pending_rounds.cc
   quorum_util.cc
   raft_consensus.cc
+  routing.cc
   time_manager.cc
 )
 
@@ -157,6 +158,7 @@ ADD_KUDU_TEST(raft_consensus_quorum-test)
 ADD_KUDU_TEST(consensus_peers-test)
 #ADD_KUDU_TEST(log_cache-test PROCESSORS 2)
 #ADD_KUDU_TEST(mt-log-test PROCESSORS 5)
+ADD_KUDU_TEST(routing-test)
 
 # Our current version of gmock overrides virtual functions without adding
 # the 'override' keyword which, since our move to c++11, make the compiler

--- a/src/kudu/consensus/consensus_meta_manager-stress-test.cc
+++ b/src/kudu/consensus/consensus_meta_manager-stress-test.cc
@@ -154,7 +154,7 @@ TEST_F(ConsensusMetadataManagerStressTest, CreateLoadDeleteTSANTest) {
         OpType type = static_cast<OpType>(rng_.Uniform(kNumOpTypes));
         switch (type) {
           case kCreate: {
-            Status s = cmeta_manager_->Create(tablet_id, config_, kInitialTerm);
+            Status s = cmeta_manager_->CreateCMeta(tablet_id, config_, kInitialTerm);
             if (tablet_cmeta_exists[tablet_id]) {
               CHECK(s.IsAlreadyPresent()) << s.ToString();
             } else {
@@ -166,7 +166,7 @@ TEST_F(ConsensusMetadataManagerStressTest, CreateLoadDeleteTSANTest) {
           }
           case kLoad: {
             scoped_refptr<ConsensusMetadata> cmeta;
-            Status s = cmeta_manager_->Load(tablet_id, &cmeta);
+            Status s = cmeta_manager_->LoadCMeta(tablet_id, &cmeta);
             if (tablet_cmeta_exists[tablet_id]) {
               CHECK(s.ok()) << s.ToString();
               ops_performed.fetch_add(1, std::memory_order_relaxed);
@@ -177,7 +177,7 @@ TEST_F(ConsensusMetadataManagerStressTest, CreateLoadDeleteTSANTest) {
             break;
           }
           case kDelete: {
-            Status s = cmeta_manager_->Delete(tablet_id);
+            Status s = cmeta_manager_->DeleteCMeta(tablet_id);
             if (tablet_cmeta_exists[tablet_id]) {
               CHECK(s.ok()) << s.ToString();
               ops_performed.fetch_add(1, std::memory_order_relaxed);

--- a/src/kudu/consensus/consensus_meta_manager.cc
+++ b/src/kudu/consensus/consensus_meta_manager.cc
@@ -16,12 +16,14 @@
 // under the License.
 #include "kudu/consensus/consensus_meta_manager.h"
 
+#include <memory>
 #include <mutex>
 #include <utility>
 
 #include <glog/logging.h>
 
 #include "kudu/consensus/consensus_meta.h"
+#include "kudu/consensus/routing.h"
 #include "kudu/fs/fs_manager.h"
 #include "kudu/gutil/map-util.h"
 #include "kudu/gutil/strings/substitute.h"
@@ -31,6 +33,7 @@ namespace kudu {
 namespace consensus {
 
 using std::lock_guard;
+using std::shared_ptr;
 using std::string;
 using strings::Substitute;
 
@@ -38,18 +41,18 @@ ConsensusMetadataManager::ConsensusMetadataManager(FsManager* fs_manager)
     : fs_manager_(DCHECK_NOTNULL(fs_manager)) {
 }
 
-Status ConsensusMetadataManager::Create(const string& tablet_id,
-                                        const RaftConfigPB& config,
-                                        int64_t initial_term,
-                                        ConsensusMetadataCreateMode create_mode,
-                                        scoped_refptr<ConsensusMetadata>* cmeta_out) {
+Status ConsensusMetadataManager::CreateCMeta(const string& tablet_id,
+                                             const RaftConfigPB& config,
+                                             int64_t initial_term,
+                                             ConsensusMetadataCreateMode create_mode,
+                                             scoped_refptr<ConsensusMetadata>* cmeta_out) {
   scoped_refptr<ConsensusMetadata> cmeta;
   RETURN_NOT_OK_PREPEND(ConsensusMetadata::Create(fs_manager_, tablet_id, fs_manager_->uuid(),
                                                   config, initial_term, create_mode,
                                                   &cmeta),
                         Substitute("Unable to create consensus metadata for tablet $0", tablet_id));
 
-  lock_guard<Mutex> l(lock_);
+  lock_guard<Mutex> l(cmeta_lock_);
   if (!InsertIfNotPresent(&cmeta_cache_, tablet_id, cmeta)) {
     return Status::AlreadyPresent(Substitute("ConsensusMetadata instance for $0 already exists",
                                              tablet_id));
@@ -58,10 +61,10 @@ Status ConsensusMetadataManager::Create(const string& tablet_id,
   return Status::OK();
 }
 
-Status ConsensusMetadataManager::Load(const string& tablet_id,
-                                      scoped_refptr<ConsensusMetadata>* cmeta_out) {
+Status ConsensusMetadataManager::LoadCMeta(const string& tablet_id,
+                                           scoped_refptr<ConsensusMetadata>* cmeta_out) {
   {
-    lock_guard<Mutex> l(lock_);
+    lock_guard<Mutex> l(cmeta_lock_);
 
     // Try to get the cmeta instance from cache first.
     scoped_refptr<ConsensusMetadata>* cached_cmeta = FindOrNull(cmeta_cache_, tablet_id);
@@ -79,7 +82,7 @@ Status ConsensusMetadataManager::Load(const string& tablet_id,
 
   // Cache and return the loaded ConsensusMetadata.
   {
-    lock_guard<Mutex> l(lock_);
+    lock_guard<Mutex> l(cmeta_lock_);
     // Due to our thread-safety contract, no other caller may have interleaved
     // with us for this tablet id, so we use InsertOrDie().
     InsertOrDie(&cmeta_cache_, tablet_id, cmeta);
@@ -89,26 +92,103 @@ Status ConsensusMetadataManager::Load(const string& tablet_id,
   return Status::OK();
 }
 
-Status ConsensusMetadataManager::LoadOrCreate(const string& tablet_id,
-                                              const RaftConfigPB& config,
-                                              int64_t initial_term,
-                                              ConsensusMetadataCreateMode create_mode,
-                                              scoped_refptr<ConsensusMetadata>* cmeta_out) {
-  Status s = Load(tablet_id, cmeta_out);
+Status ConsensusMetadataManager::LoadOrCreateCMeta(const string& tablet_id,
+                                                   const RaftConfigPB& config,
+                                                   int64_t initial_term,
+                                                   ConsensusMetadataCreateMode create_mode,
+                                                   scoped_refptr<ConsensusMetadata>* cmeta_out) {
+  Status s = LoadCMeta(tablet_id, cmeta_out);
   if (s.IsNotFound()) {
-    return Create(tablet_id, config, initial_term, create_mode, cmeta_out);
+    return CreateCMeta(tablet_id, config, initial_term, create_mode, cmeta_out);
   }
   return s;
 }
 
-Status ConsensusMetadataManager::Delete(const string& tablet_id) {
+Status ConsensusMetadataManager::DeleteCMeta(const string& tablet_id) {
   {
-    lock_guard<Mutex> l(lock_);
+    lock_guard<Mutex> l(cmeta_lock_);
     cmeta_cache_.erase(tablet_id); // OK to delete an uncached cmeta; ignore the return value.
   }
   RETURN_NOT_OK_PREPEND(ConsensusMetadata::DeleteOnDiskData(fs_manager_, tablet_id),
                         Substitute("Unable to delete consensus metadata for tablet $0", tablet_id));
   return Status::OK();
+}
+
+Status ConsensusMetadataManager::CreateDRT(const std::string& tablet_id,
+                                           RaftConfigPB raft_config,
+                                           ProxyTopologyPB proxy_topology,
+                                           std::shared_ptr<DurableRoutingTable>* drt_out) {
+  shared_ptr<DurableRoutingTable> drt;
+  RETURN_NOT_OK_PREPEND(DurableRoutingTable::Create(fs_manager_,
+                                                    tablet_id,
+                                                    std::move(raft_config),
+                                                    std::move(proxy_topology),
+                                                    &drt),
+      Substitute("Unable to create durable routing table for tablet $0", tablet_id));
+
+  lock_guard<Mutex> l(drt_lock_);
+  if (!InsertIfNotPresent(&drt_cache_, tablet_id, drt)) {
+    return Status::AlreadyPresent(Substitute("DurableRoutingTable instance for $0 already exists",
+                                             tablet_id));
+  }
+  if (drt_out) *drt_out = std::move(drt);
+  return Status::OK();
+}
+
+// Load DurableRoutingTable.
+Status ConsensusMetadataManager::LoadDRT(const std::string& tablet_id,
+                                         RaftConfigPB raft_config,
+                                         shared_ptr<DurableRoutingTable>* drt_out) {
+  {
+    lock_guard<Mutex> l(drt_lock_);
+
+    // Try to get the cmeta instance from cache first.
+    shared_ptr<DurableRoutingTable>* cached_drt = FindOrNull(drt_cache_, tablet_id);
+    if (cached_drt) {
+      if (drt_out) *drt_out = *cached_drt;
+      return Status::OK();
+    }
+  }
+
+  // If it's not yet cached, drop the lock before we load it.
+  shared_ptr<DurableRoutingTable> drt;
+  RETURN_NOT_OK_PREPEND(DurableRoutingTable::Load(fs_manager_,
+                                                  tablet_id,
+                                                  std::move(raft_config),
+                                                  &drt),
+                        Substitute("Unable to load durable routing table for tablet $0",
+                                   tablet_id));
+
+  // Cache and return the loaded DurableRoutingTable.
+  {
+    lock_guard<Mutex> l(drt_lock_);
+    // Due to our thread-safety contract, no other caller may have interleaved
+    // with us for this tablet id, so we use InsertOrDie().
+    InsertOrDie(&drt_cache_, tablet_id, drt);
+  }
+
+  if (drt_out) *drt_out = std::move(drt);
+  return Status::OK();
+}
+
+// Load or Create DurableRoutingTable.
+Status ConsensusMetadataManager::LoadOrCreateDRT(const std::string& tablet_id,
+                                                 RaftConfigPB raft_config,
+                                                 ProxyTopologyPB proxy_topology,
+                                                 std::shared_ptr<DurableRoutingTable>* drt_out) {
+  Status s = LoadDRT(tablet_id, std::move(raft_config), drt_out);
+  if (s.IsNotFound()) {
+    return CreateDRT(tablet_id, raft_config, proxy_topology, drt_out);
+  }
+  return s;
+}
+
+Status ConsensusMetadataManager::DeleteDRT(const string& tablet_id) {
+  {
+    lock_guard<Mutex> l(drt_lock_);
+    drt_cache_.erase(tablet_id); // OK to delete an uncached DRT; ignore the return value.
+  }
+  return DurableRoutingTable::DeleteOnDiskData(fs_manager_, tablet_id);
 }
 
 } // namespace consensus

--- a/src/kudu/consensus/consensus_meta_manager.h
+++ b/src/kudu/consensus/consensus_meta_manager.h
@@ -17,10 +17,12 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <unordered_map>
 
 #include "kudu/consensus/consensus_meta.h"
+#include "kudu/consensus/routing.h"
 #include "kudu/gutil/macros.h"
 #include "kudu/gutil/ref_counted.h"
 #include "kudu/util/mutex.h"
@@ -30,6 +32,7 @@ class FsManager;
 class Status;
 
 namespace consensus {
+class DurableRoutingTable;
 class RaftConfigPB;
 
 // API and implementation for a consensus metadata "manager" that controls
@@ -51,46 +54,70 @@ class ConsensusMetadataManager : public RefCountedThreadSafe<ConsensusMetadataMa
 
   // Create a ConsensusMetadata instance keyed by 'tablet_id'.
   // Returns an error if a ConsensusMetadata instance with that key already exists.
-  Status Create(const std::string& tablet_id,
-                const RaftConfigPB& config,
-                int64_t initial_term,
-                ConsensusMetadataCreateMode create_mode =
-                    ConsensusMetadataCreateMode::FLUSH_ON_CREATE,
-                scoped_refptr<ConsensusMetadata>* cmeta_out = nullptr);
+  Status CreateCMeta(const std::string& tablet_id,
+                     const RaftConfigPB& config,
+                     int64_t initial_term,
+                     ConsensusMetadataCreateMode create_mode =
+                         ConsensusMetadataCreateMode::FLUSH_ON_CREATE,
+                     scoped_refptr<ConsensusMetadata>* cmeta_out = nullptr);
 
   // Load the ConsensusMetadata instance keyed by 'tablet_id'.
   // Returns an error if it cannot be found, either in 'cmeta_cache_' or on
   // disk.
-  Status Load(const std::string& tablet_id,
-              scoped_refptr<ConsensusMetadata>* cmeta_out = nullptr);
+  Status LoadCMeta(const std::string& tablet_id,
+                   scoped_refptr<ConsensusMetadata>* cmeta_out = nullptr);
 
   // Load the ConsensusMetadata instance keyed by 'tablet_id' if it exists,
   // otherwise create it using the given parameters 'config' and
   // 'initial_term'. If the instance already exists, those parameters are
   // ignored.
-  Status LoadOrCreate(const std::string& tablet_id,
-                      const RaftConfigPB& config,
-                      int64_t initial_term,
-                      ConsensusMetadataCreateMode create_mode =
-                          ConsensusMetadataCreateMode::FLUSH_ON_CREATE,
-                      scoped_refptr<ConsensusMetadata>* cmeta_out = nullptr);
+  Status LoadOrCreateCMeta(const std::string& tablet_id,
+                           const RaftConfigPB& config,
+                           int64_t initial_term,
+                           ConsensusMetadataCreateMode create_mode =
+                               ConsensusMetadataCreateMode::FLUSH_ON_CREATE,
+                           scoped_refptr<ConsensusMetadata>* cmeta_out = nullptr);
 
   // Permanently delete the ConsensusMetadata instance keyed by 'tablet_id'.
   // Returns Status::NotFound if the instance does not exist on disk.
   // Returns another error if the cmeta instance exists but cannot be deleted
   // for some reason, perhaps due to a permissions or I/O-related issue.
-  Status Delete(const std::string& tablet_id);
+  Status DeleteCMeta(const std::string& tablet_id);
+
+  // Create DurableRoutingTable.
+  Status CreateDRT(const std::string& tablet_id,
+                   RaftConfigPB raft_config,
+                   ProxyTopologyPB proxy_topology,
+                   std::shared_ptr<DurableRoutingTable>* drt_out = nullptr);
+
+  // Load DurableRoutingTable.
+  Status LoadDRT(const std::string& tablet_id,
+                 RaftConfigPB raft_config,
+                 std::shared_ptr<DurableRoutingTable>* drt_out = nullptr);
+
+  // Load or Create DurableRoutingTable.
+  Status LoadOrCreateDRT(const std::string& tablet_id,
+                         RaftConfigPB raft_config,
+                         ProxyTopologyPB proxy_topology,
+                         std::shared_ptr<DurableRoutingTable>* drt_out = nullptr);
+
+  // Delete DurableRoutingTable.
+  Status DeleteDRT(const std::string& tablet_id);
 
  private:
   friend class RefCountedThreadSafe<ConsensusMetadataManager>;
 
   FsManager* const fs_manager_;
 
-  // Lock protecting the map below.
-  Mutex lock_;
+  // Lock protecting cmeta_cache_.
+  Mutex cmeta_lock_;
 
   // Cache for ConsensusMetadata objects (tablet_id => cmeta).
   std::unordered_map<std::string, scoped_refptr<ConsensusMetadata>> cmeta_cache_;
+
+  Mutex drt_lock_;
+  // Cache for DurableRoutingTable objects (tablet_id => drt).
+  std::unordered_map<std::string, std::shared_ptr<DurableRoutingTable>> drt_cache_;
 
   DISALLOW_COPY_AND_ASSIGN(ConsensusMetadataManager);
 };

--- a/src/kudu/consensus/metadata.proto
+++ b/src/kudu/consensus/metadata.proto
@@ -210,6 +210,17 @@ message RaftConfigPB {
   optional string replicaset_name = 6;
 }
 
+// A single directed edge on the request proxying graph.
+message ProxyEdgePB {
+  optional string peer_uuid = 1;        // Peer getting its requests proxied.
+  optional string proxy_from_uuid = 2;  // Peer to proxy from.
+}
+
+// A directed graph representation of the proxy topology.
+message ProxyTopologyPB {
+  repeated ProxyEdgePB proxy_edges = 1;
+}
+
 // Represents a snapshot of a configuration at a given moment in time.
 message ConsensusStatePB {
   // A configuration is always guaranteed to have a known term.

--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -224,7 +224,7 @@ RaftConsensus::RaftConsensus(
 
 Status RaftConsensus::Init() {
   DCHECK_EQ(kNew, state_) << State_Name(state_);
-  RETURN_NOT_OK(cmeta_manager_->Load(options_.tablet_id, &cmeta_));
+  RETURN_NOT_OK(cmeta_manager_->LoadCMeta(options_.tablet_id, &cmeta_));
   SetStateUnlocked(kInitialized);
   return Status::OK();
 }

--- a/src/kudu/consensus/raft_consensus_quorum-test.cc
+++ b/src/kudu/consensus/raft_consensus_quorum-test.cc
@@ -199,7 +199,7 @@ class RaftConsensusQuorumTest : public KuduTest {
     CHECK_EQ(config_.peers_size(), cmeta_managers_.size());
     CHECK_EQ(config_.peers_size(), fs_managers_.size());
     for (int i = 0; i < config_.peers_size(); i++) {
-      RETURN_NOT_OK(cmeta_managers_[i]->Create(kTestTablet, config_, kMinimumTerm));
+      RETURN_NOT_OK(cmeta_managers_[i]->CreateCMeta(kTestTablet, config_, kMinimumTerm));
 
       RaftPeerPB* local_peer_pb;
       RETURN_NOT_OK(GetRaftConfigMember(&config_, fs_managers_[i]->uuid(), &local_peer_pb));
@@ -555,7 +555,7 @@ class RaftConsensusQuorumTest : public KuduTest {
   // Read the ConsensusMetadata for the given peer from disk.
   scoped_refptr<ConsensusMetadata> ReadConsensusMetadataFromDisk(int peer_index) {
     scoped_refptr<ConsensusMetadata> cmeta;
-    CHECK_OK(cmeta_managers_[peer_index]->Load(kTestTablet, &cmeta));
+    CHECK_OK(cmeta_managers_[peer_index]->LoadCMeta(kTestTablet, &cmeta));
     return cmeta;
   }
 

--- a/src/kudu/consensus/routing-test.cc
+++ b/src/kudu/consensus/routing-test.cc
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "kudu/consensus/routing.h"
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include <gtest/gtest.h>
+
+#include "kudu/consensus/consensus-test-util.h"
+#include "kudu/util/test_macros.h"
+
+using std::string;
+using std::unique_ptr;
+using std::unordered_map;
+
+namespace kudu {
+namespace consensus {
+
+static void AddEdge(ProxyTopologyPB* proxy_topology, string peer, string upstream_uuid) {
+  ProxyEdgePB* edge = proxy_topology->add_proxy_edges();
+  edge->set_peer_uuid(std::move(peer));
+  edge->set_proxy_from_uuid(std::move(upstream_uuid));
+}
+
+TEST(RoutingTest, TestRoutingTable) {
+  RaftConfigPB raft_config = BuildRaftConfigPBForTests(/*num_voters=*/6);
+  raft_config.set_opid_index(1); // required for validation
+  ProxyTopologyPB proxy_topology;
+  AddEdge(&proxy_topology, /*to=*/"peer-1", /*proxy_from=*/"peer-0");
+  AddEdge(&proxy_topology, /*to=*/"peer-3", /*proxy_from=*/"peer-2");
+  AddEdge(&proxy_topology, /*to=*/"peer-4", /*proxy_from=*/"peer-3");
+  AddEdge(&proxy_topology, /*to=*/"peer-5", /*proxy_from=*/"peer-3");
+
+  // Specify a leader that has a parent (proxy_from).
+  const string kLeaderUuid = "peer-3";
+
+  RoutingTable routing_table;
+  ASSERT_OK(routing_table.Init(raft_config, proxy_topology, kLeaderUuid));
+
+  string next_hop;
+  ASSERT_OK(routing_table.NextHop("peer-3", "peer-5", &next_hop));
+  ASSERT_EQ("peer-5", next_hop);
+  ASSERT_OK(routing_table.NextHop("peer-3", "peer-1", &next_hop));
+  ASSERT_EQ("peer-0", next_hop);
+  ASSERT_OK(routing_table.NextHop("peer-5", "peer-1", &next_hop));
+  ASSERT_EQ("peer-3", next_hop);
+  ASSERT_OK(routing_table.NextHop("peer-2", "peer-4", &next_hop));
+  ASSERT_EQ("peer-3", next_hop);
+}
+
+// Test the case where an instance of "proxy_from" is not in the Raft config.
+TEST(RoutingTest, TestProxyFromNotInRaftConfig) {
+  const string kLeaderUuid = "peer-0";
+  const string kBogusUuid = "bogus";
+
+  RaftConfigPB raft_config = BuildRaftConfigPBForTests(/*num_voters=*/2);
+  raft_config.set_opid_index(1); // required for validation
+  ProxyTopologyPB proxy_topology;
+  AddEdge(&proxy_topology, /*to=*/"peer-1", /*proxy_from=*/kBogusUuid);
+
+  RoutingTable routing_table;
+  Status s = routing_table.Init(raft_config, proxy_topology, kLeaderUuid);
+  ASSERT_FALSE(s.ok()) << s.ToString();
+  ASSERT_TRUE(s.IsIncomplete()) << s.ToString();
+  ASSERT_STR_CONTAINS(s.ToString(), "have been ignored: " + kBogusUuid);
+
+  string next_hop;
+  ASSERT_OK(routing_table.NextHop(/*src_uuid=*/"peer-0", /*dest_uuid=*/"peer-1", &next_hop));
+  ASSERT_EQ("peer-1", next_hop); // Direct routing fallback.
+}
+
+} // namespace consensus
+} // namespace kudu

--- a/src/kudu/consensus/routing.cc
+++ b/src/kudu/consensus/routing.cc
@@ -1,0 +1,519 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "kudu/consensus/routing.h"
+
+#include <unordered_set>
+
+#include <glog/logging.h>
+#include <google/protobuf/util/message_differencer.h>
+
+#include "kudu/consensus/log_util.h"
+#include "kudu/consensus/quorum_util.h"
+#include "kudu/gutil/map-util.h"
+#include "kudu/gutil/strings/join.h"
+#include "kudu/gutil/strings/substitute.h"
+#include "kudu/util/env.h"
+#include "kudu/util/env_util.h"
+#include "kudu/util/locks.h"
+#include "kudu/util/logging.h"
+#include "kudu/util/pb_util.h"
+#include "kudu/util/scoped_cleanup.h"
+#include "kudu/util/status.h"
+
+using boost::optional;
+using google::protobuf::util::MessageDifferencer;
+using kudu::pb_util::SecureShortDebugString;
+using std::shared_ptr;
+using std::unique_ptr;
+using std::string;
+using std::unordered_map;
+using std::unordered_set;
+using std::vector;
+using strings::Substitute;
+
+namespace kudu {
+namespace consensus {
+
+////////////////////////////////////////////////////////////////////////////////
+// RoutingTable
+////////////////////////////////////////////////////////////////////////////////
+
+Status RoutingTable::Init(const RaftConfigPB& raft_config,
+                          const ProxyTopologyPB& proxy_topology,
+                          const std::string& leader_uuid) {
+  unordered_map<string, Node*> index;
+  unordered_map<string, unique_ptr<Node>> forest;
+
+  Status s = ConstructForest(raft_config, proxy_topology, &index, &forest);
+  if (PREDICT_FALSE(!s.ok() && !s.IsIncomplete())) {
+    return s;
+  }
+  RETURN_NOT_OK(MergeForestIntoSingleRoutingTree(leader_uuid, index, &forest));
+  ConstructNextHopIndicesRec(forest.begin()->second.get());
+
+  index_ = std::move(index);
+  topology_root_ = std::move(forest.begin()->second);
+
+  return s;
+}
+
+Status RoutingTable::ConstructForest(
+    const RaftConfigPB& raft_config,
+    const ProxyTopologyPB& proxy_topology,
+    std::unordered_map<std::string, Node*>* index,
+    std::unordered_map<std::string, std::unique_ptr<Node>>* forest) {
+
+  RETURN_NOT_OK_PREPEND(VerifyProxyTopology(proxy_topology),
+                        "invalid proxy topology");
+
+  RETURN_NOT_OK_PREPEND(VerifyRaftConfig(raft_config),
+                        "invalid raft config");
+
+  unordered_map<string, string> dest_to_proxy_from; // keyed by directed edge destination
+  for (const auto& edge : proxy_topology.proxy_edges()) {
+    InsertOrDie(&dest_to_proxy_from, edge.peer_uuid(), edge.proxy_from_uuid());
+  }
+
+  // Initially, construct a forest comprised of all peers in the Raft config,
+  // with no proxy_from relationships represented.
+  std::unordered_map<std::string, std::unique_ptr<Node>> tmp_forest;
+  std::unordered_map<std::string, Node*> tmp_index;
+  for (const RaftPeerPB& peer : raft_config.peers()) {
+    unique_ptr<Node> node(new Node(peer));
+    tmp_index.emplace(peer.permanent_uuid(), node.get());
+    tmp_forest.emplace(peer.permanent_uuid(), std::move(node));
+  }
+
+  // proxy_from nodes specified in ProxyTopologyPB that were not found in RaftConfigPB.
+  vector<string> proxy_from_nodes_not_found;
+
+  // Now, organize the forest into parent-child relationships, where the parent
+  // is represented as proxy_from in each ProxyTopologyPB edge, and the child
+  // is the destination. Any node without a valid proxy_from (either not
+  // specified in ProxyTopologyPB or specified as a peer that isn't currently a
+  // member of the Raft config) will be left as a tree root in the forest.
+  for (const RaftPeerPB& peer : raft_config.peers()) {
+    const string* proxy_from_uuid = FindOrNull(dest_to_proxy_from, peer.permanent_uuid());
+    if (!proxy_from_uuid) {
+      continue; // No 'proxy_from' specified for this peer.
+    }
+
+    // Node has proxy_from set, so we must link them and assign object
+    // ownership as a child of the proxy_from Node.
+    Node* proxy_from_ptr = FindWithDefault(tmp_index, *proxy_from_uuid, nullptr);
+    if (!proxy_from_ptr) {
+      // We skip over rules specifying proxy_from as a node not in the Raft
+      // config and we warn about it.
+      proxy_from_nodes_not_found.push_back(*proxy_from_uuid);
+      continue;
+    }
+
+    // Move destination out of forest map and into the proxy_from Node as a child.
+    const string& node_uuid = peer.permanent_uuid();
+    auto iter = tmp_forest.find(node_uuid);
+    DCHECK(iter != tmp_forest.end());
+    unique_ptr<Node> node = std::move(iter->second);
+    tmp_forest.erase(iter->first);
+    node->proxy_from = proxy_from_ptr;
+    auto result = proxy_from_ptr->children.emplace(node_uuid, std::move(node));
+    DCHECK(result.second) << "unexpected duplicate uuid: " << node_uuid;
+  }
+
+  *index = std::move(tmp_index);
+  *forest = std::move(tmp_forest);
+
+  // This is just a warning, not an error.
+  if (!proxy_from_nodes_not_found.empty()) {
+    return Status::Incomplete(
+        "the following proxy_from nodes specified in the proxy topology were "
+        "not found in the active Raft config and have been ignored",
+        JoinStrings(proxy_from_nodes_not_found, ", "));
+  }
+
+  return Status::OK();
+}
+
+Status RoutingTable::MergeForestIntoSingleRoutingTree(
+    const std::string& leader_uuid,
+    const std::unordered_map<std::string, Node*>& index,
+    std::unordered_map<std::string, std::unique_ptr<Node>>* forest) {
+  Node* leader = FindWithDefault(index, leader_uuid, nullptr);
+  if (!leader) {
+    return Status::InvalidArgument("invalid config: cannot find leader",
+                                   leader_uuid);
+  }
+
+  // Find the ultimate proxy root of the leader, if the leader as a proxy
+  // assigned to it.
+  Node* source_root = leader;
+  while (source_root->proxy_from) {
+    source_root = source_root->proxy_from;
+  }
+
+  // Make all trees, except the one the leader is in, children of the leader.
+  // The result is a single tree.
+  auto iter = forest->begin();
+  while (iter != forest->end()) {
+    if (iter->first == source_root->id()) {
+      ++iter;
+      continue;
+    }
+    const string& child_uuid = iter->first;
+    iter->second->proxy_from = leader;
+    leader->children.emplace(child_uuid, std::move(iter->second));
+    iter = forest->erase(iter);
+  }
+
+  DCHECK_EQ(1, forest->size());
+  return Status::OK();
+}
+
+void RoutingTable::ConstructNextHopIndicesRec(Node* cur) {
+  for (const auto& child_entry : cur->children) {
+    const string& child_uuid = child_entry.first;
+    const auto& child = child_entry.second;
+    ConstructNextHopIndicesRec(child.get());
+    // Absorb child routes.
+    for (const auto& child_route : child->routes) {
+      const string& dest_uuid = child_route.first;
+      cur->routes.emplace(dest_uuid, child_uuid);
+    }
+  }
+  // Add self-route as a base case.
+  cur->routes.emplace(cur->id(), cur->id());
+}
+
+Status RoutingTable::NextHop(const string& src_uuid,
+                             const string& dest_uuid,
+                             string* next_hop) const {
+  Node* src = FindWithDefault(index_, src_uuid, nullptr);
+  if (!src) {
+    return Status::NotFound(Substitute("unknown source uuid: $0", src_uuid));
+  }
+  Node* dest = FindWithDefault(index_, dest_uuid, nullptr);
+  if (!dest) {
+    return Status::NotFound(Substitute("unknown destination uuid: $0", dest_uuid));
+  }
+
+  // Search children.
+  string* next_uuid = FindOrNull(src->routes, dest_uuid);
+  if (next_uuid) {
+    *next_hop = *next_uuid;
+    return Status::OK();
+  }
+
+  // If we can't route via a child, route via a parent.
+  DCHECK(src->proxy_from);
+  *next_hop = src->proxy_from->id();
+  return Status::OK();
+}
+
+std::string RoutingTable::ToString() const {
+  string out;
+  out.reserve(4096);
+  // DFS.
+  ToStringHelperRec(topology_root_.get(), /*level=*/ 0, &out);
+  return out;
+}
+
+void RoutingTable::ToStringHelperRec(Node* cur, int level, std::string* out) const {
+  for (int i = level - 1; i >= 0; i--) {
+    if (i > 0) {
+      *out += "   ";
+    } else {
+      *out += "-> ";
+    }
+  }
+  *out += strings::Substitute("$0 ($1)\n",
+            cur->peer_pb.permanent_uuid(),
+            SecureShortDebugString(cur->peer_pb.last_known_addr()));
+  for (const auto& entry : cur->children) {
+    ToStringHelperRec(entry.second.get(), level + 1, out);
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// DurableRoutingTable
+////////////////////////////////////////////////////////////////////////////////
+
+Status DurableRoutingTable::Create(FsManager* fs_manager,
+                                   std::string tablet_id,
+                                   RaftConfigPB raft_config,
+                                   ProxyTopologyPB proxy_topology,
+                                   std::shared_ptr<DurableRoutingTable>* drt) {
+  string path = fs_manager->GetProxyMetadataPath(tablet_id);
+  if (fs_manager->env()->FileExists(path)) {
+    return Status::AlreadyPresent(Substitute("File $0 already exists", path));
+  }
+
+  auto tmp_drt = std::shared_ptr<DurableRoutingTable>(new DurableRoutingTable(fs_manager,
+                                                  std::move(tablet_id),
+                                                  std::move(proxy_topology),
+                                                  std::move(raft_config)));
+  RETURN_NOT_OK(tmp_drt->Flush()); // no lock needed as object is unpublished
+  *drt = std::move(tmp_drt);
+  return Status::OK();
+}
+
+// Read from disk.
+Status DurableRoutingTable::Load(FsManager* fs_manager,
+                                 std::string tablet_id,
+                                 RaftConfigPB raft_config,
+                                 std::shared_ptr<DurableRoutingTable>* drt) {
+  string path = fs_manager->GetProxyMetadataPath(tablet_id);
+
+  ProxyTopologyPB proxy_topology;
+  RETURN_NOT_OK(pb_util::ReadPBContainerFromPath(fs_manager->env(),
+                                                 path,
+                                                 &proxy_topology));
+
+  *drt = std::shared_ptr<DurableRoutingTable>(new DurableRoutingTable(fs_manager,
+                                          std::move(tablet_id),
+                                          std::move(proxy_topology),
+                                          std::move(raft_config)));
+  return Status::OK();
+}
+
+Status DurableRoutingTable::DeleteOnDiskData(FsManager* fs_manager, const string& tablet_id) {
+  string path = fs_manager->GetProxyMetadataPath(tablet_id);
+  RETURN_NOT_OK_PREPEND(fs_manager->env()->DeleteFile(path),
+                        Substitute("Unable to delete durable routing table file for tablet $0",
+                                   tablet_id));
+  return Status::OK();
+}
+
+Status DurableRoutingTable::UpdateProxyTopology(ProxyTopologyPB proxy_topology) {
+  // Take the write lock (does not block readers) and do the slow stuff here.
+  lock_.WriteLock();
+  auto release_write_lock = MakeScopedCleanup([&] { lock_.WriteUnlock(); });
+
+  // Rebuild the routing table.
+  RoutingTable routing_table;
+  if (leader_uuid_) {
+    Status s = routing_table.Init(raft_config_, proxy_topology, *leader_uuid_);
+    if (PREDICT_FALSE(s.IsIncomplete())) {
+      // Log but continue for Incomplete, which is a warning.
+      LOG_WITH_PREFIX(WARNING) << s.ToString();
+    } else {
+      RETURN_NOT_OK(s);
+    }
+  }
+
+  // Only flush the proxy graph protobuf to disk when it changes.
+  if (!MessageDifferencer::Equals(proxy_topology, proxy_topology_)) {
+    VLOG_WITH_PREFIX(3) << "proxy routes updated, flushing to disk...";
+    RETURN_NOT_OK(Flush());
+  }
+
+  // Upgrade to an exclusive commit lock and make atomic changes here.
+  lock_.UpgradeToCommitLock();
+  release_write_lock.cancel(); // Unlocking the commit lock releases the write lock.
+  auto release_commit_lock = MakeScopedCleanup([&] { lock_.CommitUnlock(); });
+
+  proxy_topology_ = std::move(proxy_topology);
+
+  if (leader_uuid_) {
+    routing_table_ = std::move(routing_table);
+    VLOG_WITH_PREFIX(2) << "updated proxy routes: \n" << routing_table_->ToString();
+  } else {
+    routing_table_ = boost::none;
+    VLOG_WITH_PREFIX(2) << "proxy routing disabled";
+  }
+
+  return Status::OK();
+}
+
+Status DurableRoutingTable::UpdateRaftConfig(RaftConfigPB raft_config) {
+  // Take the write lock (does not block readers) and do the slow stuff here.
+  lock_.WriteLock();
+  auto release_write_lock = MakeScopedCleanup([&] { lock_.WriteUnlock(); });
+
+  // Rebuild the routing table.
+  RoutingTable routing_table;
+  bool leader_in_config = false;
+  if (leader_uuid_) {
+    leader_in_config = IsRaftConfigMember(*leader_uuid_, raft_config);
+  }
+  if (leader_in_config) {
+    Status s = routing_table.Init(raft_config, proxy_topology_, *leader_uuid_);
+    if (PREDICT_FALSE(s.IsIncomplete())) {
+      // Log but continue for Incomplete, which is a warning.
+      LOG_WITH_PREFIX(WARNING) << s.ToString();
+    } else {
+      RETURN_NOT_OK(s);
+    }
+    VLOG_WITH_PREFIX(2) << "updated proxy routes: \n" << routing_table.ToString();
+  }
+
+  // Upgrade to an exclusive commit lock and make atomic changes here.
+  lock_.UpgradeToCommitLock();
+  release_write_lock.cancel(); // Unlocking the commit lock releases the write lock.
+  auto release_commit_lock = MakeScopedCleanup([&] { lock_.CommitUnlock(); });
+
+  raft_config_ = std::move(raft_config);
+
+  if (leader_in_config) {
+    routing_table_ = std::move(routing_table);
+    VLOG_WITH_PREFIX(2) << "updated proxy routes: \n" << routing_table_->ToString();
+  } else {
+    routing_table_ = boost::none;
+    VLOG_WITH_PREFIX(2) << "proxy routing disabled";
+  }
+
+  return Status::OK();
+}
+
+void DurableRoutingTable::UpdateLeader(string leader_uuid) {
+  // Take the write lock (does not block readers) and do the slow stuff here.
+  lock_.WriteLock();
+  auto release_write_lock = MakeScopedCleanup([&] { lock_.WriteUnlock(); });
+
+  RoutingTable routing_table;
+  bool initialized = false;
+  if (IsRaftConfigMember(leader_uuid, raft_config_)) {
+    // Rebuild the routing table. If this fails, remember the new leader anyway.
+    Status s = routing_table.Init(raft_config_, proxy_topology_, leader_uuid);
+    if (PREDICT_FALSE(s.IsIncomplete())) {
+      // Log but continue for Incomplete, which is a warning.
+      LOG_WITH_PREFIX(WARNING) << s.ToString();
+      initialized = true;
+    } else if (PREDICT_FALSE(!s.ok())) {
+      initialized = true;
+    } else {
+      LOG_WITH_PREFIX(WARNING) << "unable to initialize proxy routing table: " << s.ToString();
+    }
+  }
+
+  // Upgrade to an exclusive commit lock and make atomic changes here.
+  lock_.UpgradeToCommitLock();
+  release_write_lock.cancel(); // Unlocking the commit lock releases the write lock.
+  auto release_commit_lock = MakeScopedCleanup([&] { lock_.CommitUnlock(); });
+
+  leader_uuid_ = std::move(leader_uuid);
+  if (initialized) {
+    routing_table_ = std::move(routing_table);
+    VLOG_WITH_PREFIX(2) << "updated proxy routes: \n" << routing_table_->ToString();
+  } else {
+    routing_table_ = boost::none;
+    VLOG_WITH_PREFIX(2) << "proxy routing disabled";
+  }
+}
+
+Status DurableRoutingTable::NextHop(const std::string& src_uuid,
+                                    const std::string& dest_uuid,
+                                    std::string* next_hop) const {
+  shared_lock<RWCLock> l(lock_);
+  if (routing_table_) {
+    return routing_table_->NextHop(src_uuid, dest_uuid, next_hop);
+  }
+  if (!IsRaftConfigMember(dest_uuid, raft_config_)) {
+    return Status::NotFound(
+        Substitute("peer with uuid $0 not found in consensus config", dest_uuid));
+  }
+
+  *next_hop = dest_uuid;
+  return Status::OK();
+}
+
+ProxyTopologyPB DurableRoutingTable::GetProxyTopology() const {
+  shared_lock<RWCLock> l(lock_);
+  return proxy_topology_;
+}
+
+string DurableRoutingTable::ToString() const {
+  shared_lock<RWCLock> l(lock_);
+  if (routing_table_) {
+    return routing_table_->ToString();
+  }
+  return "";
+}
+
+DurableRoutingTable::DurableRoutingTable(FsManager* fs_manager,
+                                         string tablet_id,
+                                         ProxyTopologyPB proxy_topology,
+                                         RaftConfigPB raft_config)
+    : fs_manager_(fs_manager),
+      tablet_id_(std::move(tablet_id)),
+      proxy_topology_(std::move(proxy_topology)),
+      raft_config_(std::move(raft_config)) {
+  // TODO(mpercy): Do we have any validation to perform here?
+}
+
+Status DurableRoutingTable::Flush() const {
+  // TODO(mpercy): This entire method is copy / pasted from
+  // ConsensusMetadata::Flush(). Factor out?
+
+  // Create directories if needed.
+  string dir = fs_manager_->GetConsensusMetadataDir();
+  bool created_dir = false;
+  RETURN_NOT_OK_PREPEND(env_util::CreateDirIfMissing(
+      fs_manager_->env(), dir, &created_dir),
+                        "Unable to create consensus metadata root dir");
+  // fsync() parent dir if we had to create the dir.
+  if (PREDICT_FALSE(created_dir)) {
+    string parent_dir = DirName(dir);
+    RETURN_NOT_OK_PREPEND(Env::Default()->SyncDir(parent_dir),
+                          "Unable to fsync consensus parent dir " + parent_dir);
+  }
+
+  string path = fs_manager_->GetProxyMetadataPath(tablet_id_);
+  RETURN_NOT_OK_PREPEND(pb_util::WritePBContainerToPath(
+      fs_manager_->env(), path, proxy_topology_, pb_util::OVERWRITE,
+      // We use FLAGS_log_force_fsync_all here because the consensus metadata is
+      // essentially an extension of the primary durability mechanism of the
+      // consensus subsystem: the WAL. Using the same flag ensures that the WAL
+      // and the consensus metadata get the same durability guarantees.
+      FLAGS_log_force_fsync_all ? pb_util::SYNC : pb_util::NO_SYNC),
+          Substitute("Unable to write proxy metadata file for tablet $0 to path $1",
+                     tablet_id_, path));
+  return Status::OK();
+}
+
+string DurableRoutingTable::LogPrefix() const {
+  return strings::Substitute("T $0 P $1: ", tablet_id_, fs_manager_->uuid());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Global functions.
+////////////////////////////////////////////////////////////////////////////////
+
+Status VerifyProxyTopology(const ProxyTopologyPB& proxy_topology) {
+  unordered_set<string> seen;
+  for (const auto& entry : proxy_topology.proxy_edges()) {
+    if (entry.peer_uuid().empty()) {
+      return Status::InvalidArgument(Substitute("empty peer_uuid specified: $0",
+                                                SecureShortDebugString(entry)));
+    }
+    if (entry.proxy_from_uuid().empty()) {
+      return Status::InvalidArgument(Substitute("empty proxy_from_uuid specified: $0",
+                                                SecureShortDebugString(entry)));
+    }
+    if (entry.peer_uuid() == entry.proxy_from_uuid()) {
+      return Status::InvalidArgument(Substitute("illegal self-loop specified: $0",
+                                                SecureShortDebugString(entry)));
+    }
+    if (!InsertIfNotPresent(&seen, entry.peer_uuid())) {
+      return Status::InvalidArgument(Substitute("duplicate peer_uuid specified: $0",
+                                                entry.peer_uuid()));
+    }
+  }
+  return Status::OK();
+}
+
+} // namespace consensus
+} // namespace kudu

--- a/src/kudu/consensus/routing.h
+++ b/src/kudu/consensus/routing.h
@@ -1,0 +1,234 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include <boost/optional/optional.hpp>
+
+#include "kudu/consensus/metadata.pb.h"
+#include "kudu/fs/fs_manager.h"
+#include "kudu/util/rwc_lock.h"
+
+namespace kudu {
+
+class Status;
+
+namespace consensus {
+
+// A class that calculates the route that a message should take when being
+// proxied across a topology, given a Raft config and a leader.
+//
+// For example, given the following topology, where parents in the tree are
+// defined by setting the proxy_from field in the Raft config:
+//
+//              A            G
+//             / \          / \
+//            B   C*       H   I
+//           / \   \
+//          D   E   F
+//
+// and given that C is the leader, this implementation will assume there is a
+// direct route from C to G and thus construct a single-tree topology that
+// looks like the following:
+//
+//               A
+//             /   \
+//            B     C*
+//           / \   / \
+//          D   E F   G
+//                   / \
+//                  H   I
+//
+// Of course, the route from C to F will be C -> F.
+// Similarly, the route from C to I will be C -> G -> I.
+// To reach D from C, the route will be C -> A -> B -> D.
+// Naturally, the next hop from A to E will be B.
+//
+// This class is NOT thread-safe and must be externally synchronized..
+class RoutingTable {
+ public:
+  // Initialize the routing table. Safe to call multiple times.
+  //
+  // Returns Status::Incomplete as an information warning, yet successfully
+  // initializes the routing table, if any proxy_from edges specified in
+  // ProxyTopologyPB do not appear RaftConfigPB. In such cases, direct routing
+  // to those destinations will be used. If this is not desired, treat
+  // Status::Incomplete as an error.
+  //
+  // All other non-OK Status codes are errors and the routing table will not be
+  // left in a defined state.
+  Status Init(const RaftConfigPB& raft_config,
+              const ProxyTopologyPB& proxy_topology,
+              const std::string& leader_uuid);
+
+  // Find the UUID of the next hop, given the UUIDs of the current source
+  // and the ultimate destination.
+  Status NextHop(const std::string& src_uuid,
+                 const std::string& dest_uuid,
+                 std::string* next_hop) const;
+
+  // Return a string representation of the routing topology.
+  std::string ToString() const;
+
+ private:
+  // A node representing a raft peer in a hierarchy with associated routing
+  // rules for proxied messages.
+  struct Node {
+    explicit Node(RaftPeerPB peer_pb)
+        : peer_pb(peer_pb) {
+    }
+
+    const std::string& id() const {
+      return peer_pb.permanent_uuid();
+    }
+
+    const RaftPeerPB peer_pb;
+    Node* proxy_from = nullptr;
+
+    // children: child uuid -> child Node
+    std::unordered_map<std::string, std::unique_ptr<Node>> children;
+    // routes: dest uuid -> next hop uuid
+    std::unordered_map<std::string, std::string> routes;
+  };
+
+  // Construct a forest of Node trees that represent proxy_from relationships.
+  // Any Node that does not have a proxy_from specified in the proxy topology
+  // will appear as a root Node in the forest.
+  //
+  // Output:
+  //   index: An index keyed by the UUID of each Node.
+  //   forest: Each tree is rooted in a Node with no "proxy_from" specified.
+  //
+  // Returns InvalidArgument and fails if duplicate peers appear in the
+  // RaftConfigPB or if multiple proxy_from edges are specified for the same
+  // destination in the ProxyTopologyPB.
+  //
+  // Returns Incomplete as a warning, but successfully initializes the output
+  // variables, if any proxy_from peers specified in ProxyTopologyPB are not
+  // found in RaftConfigPB.
+  Status ConstructForest(
+      const RaftConfigPB& raft_config,
+      const ProxyTopologyPB& proxy_topology,
+      std::unordered_map<std::string, Node*>* index,
+      std::unordered_map<std::string, std::unique_ptr<Node>>* forest);
+
+  // Reorganize the given forest into a single routing tree by moving the roots
+  // of Node trees that don't include the leader under the leader as children.
+  // The leader must appear in the index. If it does not, InvalidArgument is
+  // returned.
+  Status MergeForestIntoSingleRoutingTree(
+      const std::string& leader_uuid,
+      const std::unordered_map<std::string, Node*>& index,
+      std::unordered_map<std::string, std::unique_ptr<Node>>* forest);
+
+  // Recursively construct the next-hop indices at each node. We run DFS to
+  // determine routes because there is only one route to each node from the
+  // root.
+  void ConstructNextHopIndicesRec(Node* cur);
+
+  // Recursive helper for DFS to build the debug string emitted by ToString().
+  void ToStringHelperRec(Node* cur, int level, std::string* out) const;
+
+  std::unique_ptr<Node> topology_root_;
+  std::unordered_map<std::string, Node*> index_;
+};
+
+// Thread-safe and durable metadata layer on top of RoutingTable. Only keeps
+// the ProxyTopologyPB durable. Ensures that (at most) a single instance of
+// RoutingTable is active at any given moment.
+//
+// DurableRoutingTable differs behaviorally from RoutingTable when the leader
+// is unknown. For the details, the header doc for NextHop().
+//
+class DurableRoutingTable {
+ public:
+  // Initialize for the first time and write to disk.
+  static Status Create(FsManager* fs_manager,
+                       std::string tablet_id,
+                       RaftConfigPB raft_config,
+                       ProxyTopologyPB proxy_topology,
+                       std::shared_ptr<DurableRoutingTable>* drt);
+
+  // Read from disk.
+  static Status Load(FsManager* fs_manager,
+                     std::string tablet_id,
+                     RaftConfigPB raft_config,
+                     std::shared_ptr<DurableRoutingTable>* drt);
+
+  // Delete the on-disk data for the DRT.
+  static Status DeleteOnDiskData(FsManager* fs_manager, const std::string& tablet_id);
+
+  // Called when the proxy graph changes.
+  Status UpdateProxyTopology(ProxyTopologyPB proxy_topology);
+
+  // Called when the Raft config changes.
+  Status UpdateRaftConfig(RaftConfigPB raft_config);
+
+  // Called when the leader changes.
+  void UpdateLeader(std::string leader_uuid);
+
+  // If the leader is known and 'dest_uuid' is in the raft config, returns the
+  // next hop along the route to reach 'dest_uuid'. If 'dest_uuid' is not a
+  // member of the config, returns a Status::NotFound error. If there is no
+  // known leader, but 'dest_uuid' is a member of the raft config, returns
+  // 'dest_uuid' to directly route to the node, ignoring normal proxy routing
+  // rules, since proxying routes are only defined when the leader is known.
+  Status NextHop(const std::string& src_uuid,
+                 const std::string& dest_uuid,
+                 std::string* next_hop) const;
+
+  // Return the currently active proxy topology.
+  ProxyTopologyPB GetProxyTopology() const;
+
+  // Return a string representation of the routing topology.
+  std::string ToString() const;
+
+ private:
+  DurableRoutingTable(FsManager* fs_manager,
+                      std::string tablet_id,
+                      ProxyTopologyPB proxy_topology,
+                      RaftConfigPB raft_config);
+
+  // We flush a new ProxyTopologyPB to disk before committing the updated version to memory.
+  // This method is not thread-safe and must be synchronized by taking the lock or similar.
+  Status Flush() const;
+
+  // Thread-safe log prefix helper.
+  std::string LogPrefix() const;
+
+  FsManager* fs_manager_;
+  const std::string tablet_id_;
+
+  mutable RWCLock lock_; // read-write-commit lock protecting the below fields
+  ProxyTopologyPB proxy_topology_;
+  RaftConfigPB raft_config_;
+  boost::optional<std::string> leader_uuid_; // We don't always know who is leader.
+  boost::optional<RoutingTable> routing_table_; // When leader is unknown, the route is undefined.
+};
+
+// Verify that a ProxyTopologyPB is well-formed.
+// Returns OK if no duplicates, empty strings, or self-loops are detected.
+// Does not attempt to perform multi-hop loop detection because the final
+// routing topology is not defined without a Raft config and leader.
+Status VerifyProxyTopology(const ProxyTopologyPB& proxy_topology);
+
+}  // namespace consensus
+}  // namespace kudu

--- a/src/kudu/fs/fs_manager.h
+++ b/src/kudu/fs/fs_manager.h
@@ -234,6 +234,11 @@ class FsManager {
     return JoinPathSegments(GetConsensusMetadataDir(), tablet_id);
   }
 
+  // Return the path where ProxyTopologyPB is stored.
+  std::string GetProxyMetadataPath(const std::string& tablet_id) const {
+    return JoinPathSegments(GetConsensusMetadataDir(), tablet_id + ".proxy");
+  }
+
   Env* env() { return env_; }
 
   bool read_only() const {

--- a/src/kudu/integration-tests/ts_recovery-itest.cc
+++ b/src/kudu/integration-tests/ts_recovery-itest.cc
@@ -651,7 +651,7 @@ TEST_P(TsRecoveryITestDeathTest, TestRecoverFromOpIdOverflow) {
     // We also need to update the ConsensusMetadata to match with the term we
     // want to end up with.
     scoped_refptr<ConsensusMetadata> cmeta;
-    ASSERT_OK(cmeta_manager->Load(tablet_id, &cmeta));
+    ASSERT_OK(cmeta_manager->LoadCMeta(tablet_id, &cmeta));
     cmeta->set_current_term(kDesiredIndexValue);
     ASSERT_OK(cmeta->Flush());
   }

--- a/src/kudu/tools/tool_action_local_replica.cc
+++ b/src/kudu/tools/tool_action_local_replica.cc
@@ -225,7 +225,7 @@ Status PrintReplicaUuids(const RunnerContext& context) {
 
   // Load the cmeta file and print all peer uuids.
   scoped_refptr<ConsensusMetadata> cmeta;
-  RETURN_NOT_OK(cmeta_manager->Load(tablet_id, &cmeta));
+  RETURN_NOT_OK(cmeta_manager->LoadCMeta(tablet_id, &cmeta));
   cout << JoinMapped(cmeta->CommittedConfig().peers(),
                      [](const RaftPeerPB& p){ return p.permanent_uuid(); },
                      " ") << endl;
@@ -272,7 +272,7 @@ Status RewriteRaftConfig(const RunnerContext& context) {
   // Load the cmeta file and rewrite the raft config.
   scoped_refptr<ConsensusMetadataManager> cmeta_manager(new ConsensusMetadataManager(&fs_manager));
   scoped_refptr<ConsensusMetadata> cmeta;
-  RETURN_NOT_OK(cmeta_manager->Load(tablet_id, &cmeta));
+  RETURN_NOT_OK(cmeta_manager->LoadCMeta(tablet_id, &cmeta));
   RaftConfigPB current_config = cmeta->CommittedConfig();
   RaftConfigPB new_config = current_config;
   new_config.clear_peers();
@@ -305,7 +305,7 @@ Status SetRaftTerm(const RunnerContext& context) {
   // Load the cmeta file and rewrite the raft config.
   scoped_refptr<ConsensusMetadataManager> cmeta_manager(new ConsensusMetadataManager(&fs_manager));
   scoped_refptr<ConsensusMetadata> cmeta;
-  RETURN_NOT_OK(cmeta_manager->Load(tablet_id, &cmeta));
+  RETURN_NOT_OK(cmeta_manager->LoadCMeta(tablet_id, &cmeta));
   if (new_term <= cmeta->current_term()) {
     return Status::InvalidArgument(Substitute(
         "specified term $0 must be higher than current term $1",

--- a/src/kudu/tserver/simple_tablet_manager.cc
+++ b/src/kudu/tserver/simple_tablet_manager.cc
@@ -133,7 +133,7 @@ Status TSTabletManager::Load(FsManager *fs_manager) {
   if (server_->opts().IsDistributed()) {
     LOG(INFO) << "Verifying existing consensus state";
     scoped_refptr<ConsensusMetadata> cmeta;
-    RETURN_NOT_OK_PREPEND(cmeta_manager_->Load(kSysCatalogTabletId, &cmeta),
+    RETURN_NOT_OK_PREPEND(cmeta_manager_->LoadCMeta(kSysCatalogTabletId, &cmeta),
                           "Unable to load consensus metadata for tablet " + kSysCatalogTabletId);
     ConsensusStatePB cstate = cmeta->ToConsensusStatePB();
     RETURN_NOT_OK(consensus::VerifyRaftConfig(cstate.committed_config()));
@@ -189,7 +189,7 @@ Status TSTabletManager::CreateNew(FsManager *fs_manager) {
     peer->set_member_type(RaftPeerPB::VOTER);
   }
 
-  RETURN_NOT_OK_PREPEND(cmeta_manager_->Create(kSysCatalogTabletId, config, consensus::kMinimumTerm),
+  RETURN_NOT_OK_PREPEND(cmeta_manager_->CreateCMeta(kSysCatalogTabletId, config, consensus::kMinimumTerm),
                         "Unable to persist consensus metadata for tablet " + kSysCatalogTabletId);
 
   return SetupRaft();
@@ -323,7 +323,7 @@ Status TSTabletManager::Start(bool is_first_run) {
   // SetStatusMessage("Initialized. Waiting to start...");
 
   scoped_refptr<ConsensusMetadata> cmeta;
-  Status s = cmeta_manager_->Load(kSysCatalogTabletId, &cmeta);
+  Status s = cmeta_manager_->LoadCMeta(kSysCatalogTabletId, &cmeta);
 
   consensus::ConsensusBootstrapInfo bootstrap_info;
   // Abstracted logs will do their own log recovery
@@ -413,7 +413,7 @@ Status TSTabletManager::SetupRaft() {
 
   // Not sure these 2 lines are required
   scoped_refptr<ConsensusMetadata> cmeta;
-  Status s = cmeta_manager_->Load(kSysCatalogTabletId, &cmeta);
+  Status s = cmeta_manager_->LoadCMeta(kSysCatalogTabletId, &cmeta);
 
   // Open the log, while passing in the factory class.
   // Factory could be empty.


### PR DESCRIPTION
This is a split of the first two patches in PR #42 

These patches are primarily concerned with routing rules and durability of the associated metadata, along with plumbing to get that information from the tablet server implementation down into the Raft consensus subsystem.

Includes a couple of (fairly basic) tests of the routing logic.