### PR TITLE
disable TLS 1.3 for kuduraft

### DIFF
--- a/src/kudu/rpc/client_negotiation.cc
+++ b/src/kudu/rpc/client_negotiation.cc
@@ -473,7 +473,9 @@ Status ClientNegotiation::HandleTlsHandshake(const NegotiatePB& response) {
     return Status::NotAuthorized("expected TLS_HANDSHAKE step",
                                  NegotiatePB::NegotiateStep_Name(response.step()));
   }
-  TRACE("Received TLS_HANDSHAKE response from server");
+  if (!response.tls_handshake().empty()) {
+    TRACE("Received TLS_HANDSHAKE response from server");
+  }
 
   if (PREDICT_FALSE(!response.has_tls_handshake())) {
     return Status::NotAuthorized("No TLS handshake token in TLS_HANDSHAKE response from server");

--- a/src/kudu/security/tls_context.cc
+++ b/src/kudu/security/tls_context.cc
@@ -61,6 +61,9 @@
 #ifndef SSL_OP_NO_TLSv1_1
 #define SSL_OP_NO_TLSv1_1 0x10000000U
 #endif
+#ifndef SSL_OP_NO_TLSv1_3
+#define SSL_OP_NO_TLSv1_3 0x20000000U
+#endif
 #ifndef TLS1_1_VERSION
 #define TLS1_1_VERSION 0x0302
 #endif
@@ -164,6 +167,10 @@ Status TlsContext::Init() {
     return Status::InvalidArgument("unknown value provided for --rpc_tls_min_protocol flag",
                                    tls_min_protocol_);
   }
+
+  // We don't currently support TLS 1.3 because the one-and-a-half-RTT negotiation
+  // confuses our RPC negotiation protocol. See KUDU-2871.
+  options |= SSL_OP_NO_TLSv1_3;
 
   SSL_CTX_set_options(ctx_.get(), options);
 


### PR DESCRIPTION
Summary:
openssl 1.1.1 enable TLS1.3. but kudu doesn't support TLS1.3. see issue:
https://issues.apache.org/jira/browse/KUDU-2871

Port the temporary fix from Alexey:
The temporary fix of pegging max TLS version to TLSv1.2 has been
submitted into the main trunk and branch-1.10.x of the Kudu git repo:
https://github.com/apache/kudu/commit/efc3f372e8b9254ab6b65d1f884381016329611c
https://github.com/apache/kudu/commit/86a0dc29fcfd3b6fd2eb8089839e0379b8dd62f4
