### PR TITLE
Proxy: prevent routing loops and fix a caching bug

### DIFF
--- a/src/kudu/consensus/consensus.proto
+++ b/src/kudu/consensus/consensus.proto
@@ -419,6 +419,9 @@ message ConsensusRequestPB {
   // Must be set if this request was proxied on behalf of the leader.
   optional bytes proxy_caller_uuid = 13;
 
+  // Hop count / TTL field for proxy requests.
+  optional int32 proxy_hops_remaining = 14;
+
   // The caller's term. As only leaders can send messages,
   // replicas will accept all messages as long as the term
   // is equal to or higher than the last term they know about.

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -1042,6 +1042,7 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   scoped_refptr<Counter> raft_proxy_num_requests_success_;
   scoped_refptr<Counter> raft_proxy_num_requests_unknown_dest_;
   scoped_refptr<Counter> raft_proxy_num_requests_log_read_timeout_;
+  scoped_refptr<Counter> raft_proxy_num_requests_hops_remaining_exhausted_;
 
   DISALLOW_COPY_AND_ASSIGN(RaftConsensus);
 };


### PR DESCRIPTION
This PR includes a bug fix for a proxy caching bug and a feature to prevent proxy routing loops.

I tested both of these with automated tests which are not included in this repo. The bug fix is tested in fbcode and the routing loop prevention is tested in the kudu repo version of this patch.