### PR TITLE
Adding an option to bootstrap the ring using passed in peers

### DIFF
--- a/src/kudu/tserver/simple_tablet_manager.h
+++ b/src/kudu/tserver/simple_tablet_manager.h
@@ -63,6 +63,8 @@ class OpId;
 struct ElectionResult;
 } // namespace consensus
 
+namespace KC = kudu::consensus;
+
 namespace tserver {
 class TabletServer;
 struct TabletServerOptions;
@@ -172,6 +174,15 @@ class TSTabletManager : public consensus::ConsensusRoundHandler {
   Status CreateDistributedConfig(const TabletServerOptions& options,
                                  consensus::RaftConfigPB* committed_config);
 
+  Status CreateConfigFromTserverAddresses(
+      const TabletServerOptions& options,
+      KC::RaftConfigPB *new_config);
+
+  void CreateConfigFromBootstrapPeers(
+      const TabletServerOptions& options,
+      KC::RaftConfigPB *new_config);
+
+ private:
   FsManager* const fs_manager_;
 
   const scoped_refptr<consensus::ConsensusMetadataManager> cmeta_manager_;

--- a/src/kudu/tserver/tablet_server_options.cc
+++ b/src/kudu/tserver/tablet_server_options.cc
@@ -110,7 +110,9 @@ TabletServerOptions::TabletServerOptions() {
 }
 
 bool TabletServerOptions::IsDistributed() const {
-  return !tserver_addresses.empty();
+  // bootstrap can happen via tserver_addresses
+  // or bootstrap_tservers
+  return !tserver_addresses.empty() || !bootstrap_tservers.empty();
 }
 
 } // namespace tserver

--- a/src/kudu/tserver/tablet_server_options.h
+++ b/src/kudu/tserver/tablet_server_options.h
@@ -34,6 +34,8 @@ class OpId;
 struct ElectionResult;
 }
 
+namespace KC = kudu::consensus;
+
 namespace tserver {
 
 // Options for constructing a tablet server.
@@ -48,6 +50,10 @@ struct TabletServerOptions : public kudu::server::ServerBaseOptions {
   std::vector<HostPort> tserver_addresses;
   std::vector<std::string> tserver_regions;
   std::vector<bool> tserver_bbd;
+
+  // bootstrap tservers can be directly passed in
+  // by application
+  std::vector<KC::RaftPeerPB> bootstrap_tservers;
 
   std::shared_ptr<kudu::log::LogFactory> log_factory;
 


### PR DESCRIPTION
Summary: In order to support non voter types during bootstrap,
we allow applications to use the option to pass in RaftPeerPB
to the TabletServer. Since the RaftPeerPB has the voter type
field, it can be used to support NON_VOTER type.

Over time we will encourage applications to move away from
options.tserver_addresses

Test Plan: Tested this with unit tests on the facebook application
side

Reviewers: bhatvinay, yichenshen

Subscribers:

Tasks:

Tags: