### PR TITLE
We return the pending config via Raft Consensus if it exists

### DIFF
--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -2762,6 +2762,16 @@ RaftConfigPB RaftConsensus::CommittedConfig() const {
   return cmeta_->CommittedConfig();
 }
 
+Status RaftConsensus::PendingConfig(RaftConfigPB *pendingConfig) const {
+  ThreadRestrictions::AssertWaitAllowed();
+  LockGuard l(lock_);
+  if (cmeta_->has_pending_config()) {
+    *pendingConfig = cmeta_->PendingConfig();
+    return Status::OK();
+  }
+  return Status::NotFound("No pending config found");
+}
+
 void RaftConsensus::DumpStatusHtml(std::ostream& out) const {
   RaftPeerPB::Role role;
   {

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -441,6 +441,9 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   // Returns a copy of the current committed Raft configuration.
   RaftConfigPB CommittedConfig() const;
 
+  // Returns a copy of the current pending Raft configuration.
+  Status PendingConfig(RaftConfigPB *pendingConfig) const;
+
   void DumpStatusHtml(std::ostream& out) const;
 
   // Transition to kStopped state. See State enum definition for details.


### PR DESCRIPTION
Summary: In order to return a pair of committed as well
as pending config to automation/clients, we need to access
the pending config. We add a simple function for this.

Test Plan: We wrote an end 2 end test on facebook code side,
which creates a small ring and accesses the Configuration state
pair during the config change event

Reviewers: bhatvinay, iritwik

Subscribers:

Tasks:

Tags: