### PR TITLE
Allow for first run log init recovery if application says so

### DIFF
--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -599,6 +599,15 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   // enum documents legal state transitions.
   void SetStateUnlocked(State new_state);
 
+  // To be only called during bootstrap, by simple_tablet_manager to
+  // make sure that the term of the instance is atleast as high as the
+  // term of its last logged entry.
+  //
+  // Just like SetCurrentTermUnlocked, this function does not let the
+  // term to reduce, and will return IlegalState for that case. So should
+  // be called only if LogTerm is higher.
+  Status SetCurrentTermBootstrap(int64_t new_term);
+
   // Returns string description for State enum value.
   static const char* State_Name(State state);
 

--- a/src/kudu/tserver/simple_tablet_manager.h
+++ b/src/kudu/tserver/simple_tablet_manager.h
@@ -204,6 +204,8 @@ class TSTabletManager : public consensus::ConsensusRoundHandler {
 
   TSTabletManagerStatePB state_;
 
+  consensus::ConsensusBootstrapInfo bootstrap_info_;
+
   // Function to mark this TabletReplica's tablet as dirty in the TSTabletManager.
   //
   // Must be called whenever cluster membership or leadership changes, or when

--- a/src/kudu/tserver/tablet_server.h
+++ b/src/kudu/tserver/tablet_server.h
@@ -99,6 +99,7 @@ class TabletServer : public kserver::KuduServer {
 
  private:
   friend class TabletServerTestBase;
+  friend class TSTabletManager;
 
 #ifdef FB_DO_NOT_REMOVE
   Status ValidateMasterAddressResolution() const;

--- a/src/kudu/tserver/tablet_server_options.h
+++ b/src/kudu/tserver/tablet_server_options.h
@@ -73,6 +73,10 @@ struct TabletServerOptions : public kudu::server::ServerBaseOptions {
   std::function<void()> ldcb;
   bool disable_noop = false;
 
+  // This is to enable a fresh instance join the ring with logs from
+  // a certain opid and term.
+  bool log_bootstrap_on_first_run = false;
+
   consensus::TopologyConfigPB topology_config;
 
   bool IsDistributed() const;


### PR DESCRIPTION
Summary: This is for the case where the logs are in a different
directory that consensus-metadata. The init of the logs helps
figure out the Last Log Opid and Committed Opid, while the
consensus metadata is for the term and the committed config, which
is still missing. In the future, we plan to expect a copied
consensus-metadata from a previous instance.

The workaround to allow setting the term unblocks witness mode
for now.

Test Plan: used this to check that a witness does not start
from 1:1

Reviewers: yashtc

Subscribers:

Tasks:

Tags: