### PR TITLE
After Shutdown() turn initted_ flag off

### DIFF
--- a/src/kudu/tserver/tablet_server.cc
+++ b/src/kudu/tserver/tablet_server.cc
@@ -204,6 +204,7 @@ void TabletServer::Shutdown() {
     // 3. Shut down generic subsystems.
     KuduServer::Shutdown();
     LOG(INFO) << name << " shutdown complete.";
+    initted_ = false;
   }
 }
 


### PR DESCRIPTION
Summary: So that it doesnt give the wrong impression that tserver is shutdown multiple times.

Test Plan:Tested as part of diff on fb side, where we made sure the
shutdown messages only appear once.

Reviewers: bhatvinay

Subscribers:

Tasks:

Tags: