### PR TITLE
Allow metrics log dir to be overriden from options

### DIFF
--- a/src/kudu/server/server_base.cc
+++ b/src/kudu/server/server_base.cc
@@ -664,11 +664,15 @@ Status ServerBase::StartMetricsLogging() {
   if (options_.metrics_log_interval_ms <= 0) {
     return Status::OK();
   }
-  if (FLAGS_log_dir.empty()) {
+  std::string& log_dir = FLAGS_log_dir;
+  if (!options_.metrics_log_dir.empty()) {
+    log_dir = options_.metrics_log_dir;
+  }
+  if (log_dir.empty()) {
     LOG(INFO) << "Not starting metrics log since no log directory was specified.";
     return Status::OK();
   }
-  unique_ptr<DiagnosticsLog> l(new DiagnosticsLog(FLAGS_log_dir, metric_registry_.get()));
+  unique_ptr<DiagnosticsLog> l(new DiagnosticsLog(log_dir, metric_registry_.get()));
   l->SetMetricsLogInterval(MonoDelta::FromMilliseconds(options_.metrics_log_interval_ms));
   RETURN_NOT_OK(l->Start());
   diag_log_ = std::move(l);

--- a/src/kudu/server/server_base_options.h
+++ b/src/kudu/server/server_base_options.h
@@ -36,7 +36,7 @@ namespace server {
 // The subclass constructor should fill these in with defaults from
 // server-specific flags.
 struct ServerBaseOptions {
-  Env* env;
+  Env *env;
 
   FsManagerOpts fs_opts;
   RpcServerOptions rpc_opts;
@@ -49,9 +49,10 @@ struct ServerBaseOptions {
   std::string dump_info_format;
   std::string app_provided_instance_uuid;
 
+  std::string metrics_log_dir;
   int32_t metrics_log_interval_ms;
 
- protected:
+protected:
   ServerBaseOptions();
 };
 


### PR DESCRIPTION
Summary:

We have a multithreaded test harness that sets up multiple rings in a
single process. FLAGS_log_dir is process wide and causes race
conditions. Here we allow a per kudu instance log dir.

Test Plan:

Run test fb side that makes use of the multithreaded harness. The
previous issue was that we get metric file conflicts, which should no
longer happen now that each instance is in a different directory.

Reviewers: anirbanr-fb, bhatvinay

Subscribers:

Tasks:

Tags:
Signed-off-by: Yichen <yichenshen@fb.com>