### PR TITLE
The redefinition of dlopen started exposing a link time issue inside fb

### DIFF
--- a/src/kudu/util/CMakeLists.txt
+++ b/src/kudu/util/CMakeLists.txt
@@ -121,6 +121,8 @@ else ()
   set(SEMAPHORE_CC "semaphore.cc")
 endif()
 
+# removing this file since it tries to override dlopen
+# debug/unwind_safeness.cc
 set(UTIL_SRCS
   async_logger.cc
   atomic.cc
@@ -138,7 +140,6 @@ set(UTIL_SRCS
   debug/trace_event_impl.cc
   debug/trace_event_impl_constants.cc
   debug/trace_event_synthetic_delay.cc
-  debug/unwind_safeness.cc
   easy_json.cc
   env.cc env_posix.cc env_util.cc
   errno.cc

--- a/src/kudu/util/debug/unwind_safeness.h
+++ b/src/kudu/util/debug/unwind_safeness.h
@@ -23,7 +23,11 @@ namespace debug {
 //
 // It's almost always safe unless we are in a signal handler context
 // inside a call into libdl.
-bool SafeToUnwindStack();
+// TODO - for now, its not clear which one is more safe.
+// so due to the dlopen, issue turning this whole functionality off.
+// We can revisit this soon. But reimplementing dlopen does not seem
+// like something that will work when kuduraft is a library
+bool SafeToUnwindStack() { return false; }
 
 } // namespace debug
 } // namespace kudu


### PR DESCRIPTION
Summary: removing these overrides as the stack unwinding functionality
does not seem critical (needs a revisit) and definitely looks risky when
used in library mode

Test Plan: Built all fb side tests and then ran them. they worked fine.
the linkage issues were resolved. Built kudu and the entire code built.

Reviewers:

Subscribers:

Tasks:

Tags: