### PR TITLE
Adding hostname as an optional string field to RaftPeerPB

### DIFF
--- a/src/kudu/consensus/metadata.proto
+++ b/src/kudu/consensus/metadata.proto
@@ -202,6 +202,8 @@ message RaftPeerPB {
   // Replica's health report, as seen by the leader. This is a run-time
   // only field, it should not be persisted or read from the persistent storage.
   optional HealthReportPB health_report = 5;
+
+  optional string hostname = 6;
 }
 
 // A set of peers, serving a single tablet.


### PR DESCRIPTION
Summary: IP addresses are difficult to deal with. These hostnames are
passed in during bootstrap and then kept persistent in this protobuf

Test Plan: Tested it by building a mysqld rpm and getting the raft
toplogy after bootstrap

Reviewers: bhatvinay, yichenshen

Subscribers:

Tasks:

Tags: