### PR TITLE
[kuduraft] change read api into log to have the uuid of the destination

### DIFF
--- a/src/kudu/consensus/consensus_queue.cc
+++ b/src/kudu/consensus/consensus_queue.cc
@@ -704,6 +704,7 @@ Status PeerMessageQueue::RequestForPeer(const string& uuid,
     // We try to get the follower's next_index from our log.
     Status s = log_cache_.ReadOps(peer_copy.next_index - 1,
                                   max_batch_size,
+                                  uuid,
                                   &messages,
                                   &preceding_id);
     if (PREDICT_FALSE(!s.ok())) {

--- a/src/kudu/consensus/log-test.cc
+++ b/src/kudu/consensus/log-test.cc
@@ -586,7 +586,7 @@ TEST_P(LogTestOptionalCompression, TestGCWithLogRunning) {
     vector<ReplicateMsg*> repls;
     ElementDeleter d(&repls);
     Status s = log_->reader()->ReadReplicatesInRange(
-      1, 2, LogReader::kNoSizeLimit, &repls);
+      1, 2, LogReader::kNoSizeLimit, /*for_peer_uuid=*/boost::none, &repls);
     ASSERT_TRUE(s.IsNotFound()) << s.ToString();
   }
 
@@ -977,7 +977,11 @@ TEST_P(LogTestOptionalCompression, TestReadLogWithReplacedReplicates) {
         vector<ReplicateMsg*> repls;
         ElementDeleter d(&repls);
         ASSERT_OK(log_->reader()->ReadReplicatesInRange(
-                    start_index, end_index, LogReader::kNoSizeLimit, &repls));
+                    start_index,
+                    end_index,
+                    LogReader::kNoSizeLimit,
+                    /*for_peer_uuid=*/boost::none,
+                    &repls));
         ASSERT_EQ(end_index - start_index + 1, repls.size());
         int expected_index = start_index;
         for (const ReplicateMsg* repl : repls) {
@@ -1001,7 +1005,12 @@ TEST_P(LogTestOptionalCompression, TestReadLogWithReplacedReplicates) {
                                 start_index, end_index, size_limit));
         vector<ReplicateMsg*> repls;
         ElementDeleter d(&repls);
-        ASSERT_OK(reader->ReadReplicatesInRange(start_index, end_index, size_limit, &repls));
+        ASSERT_OK(reader->ReadReplicatesInRange(
+              start_index,
+              end_index,
+              size_limit,
+              /*for_peer_uuid=*/boost::none,
+              &repls));
         ASSERT_LE(repls.size(), end_index - start_index + 1);
         int total_size = 0;
         int expected_index = start_index;
@@ -1044,8 +1053,12 @@ TEST_P(LogTestOptionalCompression, TestReadReplicatesHighIndex) {
   shared_ptr<LogReader> reader = log_->reader();
   vector<ReplicateMsg*> replicates;
   ElementDeleter deleter(&replicates);
-  ASSERT_OK(reader->ReadReplicatesInRange(first_log_index, first_log_index + kSequenceLength - 1,
-                                          LogReader::kNoSizeLimit, &replicates));
+  ASSERT_OK(reader->ReadReplicatesInRange(
+        first_log_index,
+        first_log_index + kSequenceLength - 1,
+        LogReader::kNoSizeLimit,
+        /*for_peer_uuid=*/boost::none,
+        &replicates));
   ASSERT_EQ(kSequenceLength, replicates.size());
   ASSERT_GT(op_id.index(), std::numeric_limits<int32_t>::max());
 }

--- a/src/kudu/consensus/log.cc
+++ b/src/kudu/consensus/log.cc
@@ -30,6 +30,7 @@
 #include <ostream>
 #include <utility>
 
+#include <boost/optional/optional.hpp>
 #include <boost/range/adaptor/reversed.hpp>
 #include <gflags/gflags.h>
 
@@ -1007,6 +1008,7 @@ Status Log::ReadReplicatesInRange(
     int64_t starting_at,
     int64_t up_to,
     int64_t max_bytes_to_read,
+    const boost::optional<std::string>& /* for_peer_uuid */,
     std::vector<consensus::ReplicateMsg*>* replicates) const {
   return reader()->ReadReplicatesInRange(
       starting_at, up_to, max_bytes_to_read, replicates);

--- a/src/kudu/consensus/log.h
+++ b/src/kudu/consensus/log.h
@@ -33,6 +33,7 @@
 #include <string>
 #include <vector>
 
+#include <boost/optional/optional.hpp>
 #include <glog/logging.h>
 #include <gtest/gtest_prod.h>
 
@@ -302,6 +303,7 @@ class Log : public RefCountedThreadSafe<Log> {
       int64_t starting_at,
       int64_t up_to,
       int64_t max_bytes_to_read,
+      const boost::optional<std::string>& for_peer_uuid,
       std::vector<consensus::ReplicateMsg*>* replicates) const;
   virtual Status LookupOpId(int64_t op_index, consensus::OpId* op_id) const;
 

--- a/src/kudu/consensus/log_cache.cc
+++ b/src/kudu/consensus/log_cache.cc
@@ -24,6 +24,7 @@
 #include <utility>
 #include <vector>
 
+#include <boost/optional/optional.hpp>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <google/protobuf/wire_format_lite.h>
@@ -310,6 +311,7 @@ int64_t TotalByteSizeForMessage(const ReplicateMsg& msg) {
 
 Status LogCache::ReadOps(int64_t after_op_index,
                          int max_size_bytes,
+                         const boost::optional<std::string>& for_peer_uuid,
                          std::vector<ReplicateRefPtr>* messages,
                          OpId* preceding_op) {
   DCHECK_GE(after_op_index, 0);
@@ -340,7 +342,7 @@ Status LogCache::ReadOps(int64_t after_op_index,
       vector<ReplicateMsg*> raw_replicate_ptrs;
       RETURN_NOT_OK_PREPEND(
         log_->ReadReplicatesInRange(
-          next_index, up_to, remaining_space, &raw_replicate_ptrs),
+          next_index, up_to, remaining_space, for_peer_uuid, &raw_replicate_ptrs),
         Substitute("Failed to read ops $0..$1", next_index, up_to));
       l.lock();
       VLOG_WITH_PREFIX_UNLOCKED(2)

--- a/src/kudu/consensus/log_cache.h
+++ b/src/kudu/consensus/log_cache.h
@@ -24,6 +24,7 @@
 #include <string>
 #include <vector>
 
+#include <boost/optional/optional.hpp>
 #include <gtest/gtest_prod.h>
 
 #include "kudu/consensus/ref_counted_replicate.h"
@@ -84,6 +85,7 @@ class LogCache {
   // of time and should not be called with important locks held, etc.
   Status ReadOps(int64_t after_op_index,
                  int max_size_bytes,
+                 const boost::optional<std::string>& for_peer_uuid,
                  std::vector<ReplicateRefPtr>* messages,
                  OpId* preceding_op);
 

--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -3739,10 +3739,12 @@ void RaftConsensus::HandleProxyRequest(const ConsensusRequestPB* request,
       // TODO(mpercy): Add an API for ReadOps() to take number of ops we want,
       // instead of the max batch size.
       if (request->ops_size() > 0) {
-        RET_RESPOND_ERROR_NOT_OK(queue_->log_cache()->ReadOps(first_op_index - 1,
-                                                              max_batch_size,
-                                                              &messages,
-                                                              &preceding_id));
+        RET_RESPOND_ERROR_NOT_OK(queue_->log_cache()->ReadOps(
+              first_op_index - 1,
+              max_batch_size,
+              request->dest_uuid(),
+              &messages,
+              &preceding_id));
       }
 
       // Exit retry loop if we managed to get what we wanted.


### PR DESCRIPTION
Summary:
Adds the uuid parameter into the read api of log_cache and log:
LogCache::ReadOps() and Log::ReadReplicatesInRange(). This is needed so that the
BinlogWrapper can have access to the destination uuid to reprt error when the
OpId to be read is not found either in th index chunk or in the binlog file.

Test Plan:

Reviewers: arahut

Subscribers:

Tasks:

Tags: