### PR TITLE
Ldcb change to pass in term

### DIFF
--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -126,7 +126,7 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   typedef std::function<void(const ElectionResult&)> ElectionDecisionCallback;
   typedef std::function<void(int64_t)> TermAdvancementCallback;
   typedef std::function<void(const OpId opId)> NoOpReceivedCallback;
-  typedef std::function<void()> LeaderDetectedCallback;
+  typedef std::function<void(int64_t)> LeaderDetectedCallback;
 
   // Modes for StartElection().
   enum ElectionMode {
@@ -893,8 +893,8 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   void ScheduleNoOpReceivedCallback(const ReplicateRefPtr& msg);
   void DoNoOpReceivedCallback(const OpId opid);
 
-  void ScheduleLeaderDetectedCallback();
-  void DoLeaderDetectedCallback();
+  void ScheduleLeaderDetectedCallback(int64_t term);
+  void DoLeaderDetectedCallback(int64_t term);
 
   // Checks if the term change is legal. If so, sets 'current_term'
   // to 'new_term' and sets 'has voted' to no for the current term.

--- a/src/kudu/tserver/simple_tablet_manager.cc
+++ b/src/kudu/tserver/simple_tablet_manager.cc
@@ -479,7 +479,7 @@ Status TSTabletManager::SetupRaft() {
   //
   // However, for the MySQL case, we allow logs to be copied from a previous
   // instance while this instance is still new (is_first_run) and
-  // going to be added to the ring. In that mode, the consensus-metadata filess
+  // going to be added to the ring. In that mode, the consensus-metadata files
   // are not copied from the previous instance (this might change in the future).
   // The cmeta is actually built from the options parameters.
   // Using :

--- a/src/kudu/tserver/tablet_server_options.h
+++ b/src/kudu/tserver/tablet_server_options.h
@@ -70,7 +70,7 @@ struct TabletServerOptions : public kudu::server::ServerBaseOptions {
 
   // Leader Detected Callback. This should eventually be reconciled
   // with NORCB.
-  std::function<void()> ldcb;
+  std::function<void(int64_t)> ldcb;
   bool disable_noop = false;
 
   // This is to enable a fresh instance join the ring with logs from


### PR DESCRIPTION
Summary: The mysql raft plugin uses terms to block out stale callbackss
(which are on async path), and also order callbacks. For example if in
some pathological scenario LDCB gets delivered before TACB, then
the handler REPLICA could get stuck in read-only+ abort mode. However
with proper Terms, we can always call TACB from LDCB if TACB has not
been called previously, and also blocking out the redundant TACB.

Test Plan: Testing on raft plugin side to call TACB from LDCB

Reviewers: bhatvinay, yichenshen

Subscribers:

Tasks:

Tags: