### PR TITLE
Adding a rotate event type to the op_types list

### DIFF
--- a/src/kudu/consensus/consensus.proto
+++ b/src/kudu/consensus/consensus.proto
@@ -144,6 +144,7 @@ enum OperationType {
   CHANGE_CONFIG_OP = 5;
   WRITE_OP_EXT = 6;
   PROXY_OP = 7;
+  ROTATE_OP = 8;
 }
 
 /*


### PR DESCRIPTION
Summary: We will need to start tagging replicate msgs with rotate types.
The reason is if we don't do that, we cannot quickly identify messages
as rotate events in AsyncAppendReplicates or StartFollowerTransaction.
It would need us to parse out the entire replicate msg which can be
expensive.

Rotate types will be used to manage appended but not committed rotates.
When a chained rotate happens, the newer rotate will become the point
of rotation

Test Plan: Testing this on MySQL side with tagging messages with rotate
and solving triple rotate issue.

Reviewers: bhatvinay, yichenshen

Subscribers:

Tasks:

Tags: