### PR TITLE
[kuduraft] region_durable_index maintainance in consensus_queue

### DIFF
--- a/src/kudu/consensus/consensus.proto
+++ b/src/kudu/consensus/consensus.proto
@@ -484,6 +484,12 @@ message ConsensusRequestPB {
   // The index of the most recent operation appended to the leader.
   // Followers can use this to determine roughly how far behind they are from the leader.
   optional int64 last_idx_appended_to_leader = 11;
+
+  // The index that is deemed to have been 'region-durable'. Region durability
+  // is currently defined as the OpId that is replicated to atleast one
+  // additional region (other than the leader's region). This is sent by the
+  // leader to all followers and they sync their queue state with this index.
+  optional int64 region_durable_index = 15;
 }
 
 message ConsensusResponsePB {

--- a/src/kudu/consensus/consensus_queue-test.cc
+++ b/src/kudu/consensus/consensus_queue-test.cc
@@ -960,7 +960,8 @@ TEST_F(ConsensusQueueTest, TestFollowerCommittedIndexAndMetrics) {
   // Update the committed index. In real life, this would be done by the consensus
   // implementation when it receives an updated committed index from the leader.
   queue_->UpdateFollowerWatermarks(/*committed_index=*/ 10,
-                                   /*all_replicated_index=*/ 10);
+                                   /*all_replicated_index=*/ 10,
+                                   /*region_durable_index=*/-1);
   ASSERT_EQ(10, queue_->GetCommittedIndex());
 
   // Check the metrics have the right values based on the updated committed index.

--- a/src/kudu/consensus/log.h
+++ b/src/kudu/consensus/log.h
@@ -510,9 +510,11 @@ public:
 // logs need to be retained for either purposes.
 struct RetentionIndexes {
   explicit RetentionIndexes(int64_t durability = std::numeric_limits<int64_t>::max(),
-                            int64_t peers = std::numeric_limits<int64_t>::max())
+                            int64_t peers = std::numeric_limits<int64_t>::max(),
+                            int64_t region_durability = std::numeric_limits<int64_t>::max())
       : for_durability(durability),
-        for_peers(peers) {}
+        for_peers(peers),
+        for_region_durability(region_durability) {}
 
   // The minimum log entry index which *must* be retained in order to
   // preserve durability and the ability to restart the local node
@@ -524,6 +526,13 @@ struct RetentionIndexes {
   // still be GCed in the case that they are from very old log segments
   // or the log has become too large.
   int64_t for_peers;
+
+  // The minimum log entry index which *should* be retained in order to ensure
+  // 'region-durability'. Region durability is currently defined as the OpId
+  // that is replicated to atleast one additional region (other than the
+  // leader's region). Useful only when the raft ring is configured to have
+  // nodes in different region
+  int64_t for_region_durability;
 };
 
 


### PR DESCRIPTION
Summary:
A new region_durable_index is defined and maintained by consensus_queue.
An index is considered to be region-durable if the OpId is replicates atleast to
one additional region other than the leader's region. This index is propagated
on every request (through ConsensusRequestPB message) sent by the leader (or
proxy) and the follower syncs his own view of region_durable_index with the
leader's view of this index. This is useful for upper layers to implement purge
(or garbage collection) policy for the log files. Note that this index is useful
only when the raft ring is configured to have nodes in multiple regions (as
defined by RaftPeerAttrsPB). The index is exposed to upper layers through
RetentionIndex (RaftConsensus::GetRetentionIndex)

Test Plan: tests to be added in mtr and fbcode side

Reviewers: arahut

Subscribers:

Tasks:

Tags: