### PR TITLE
[kuduraft] memory management for index chunks

### DIFF
--- a/src/kudu/consensus/log_index.h
+++ b/src/kudu/consensus/log_index.h
@@ -25,6 +25,7 @@
 #include "kudu/gutil/macros.h"
 #include "kudu/gutil/ref_counted.h"
 #include "kudu/util/locks.h"
+#include "kudu/util/metrics.h"
 #include "kudu/util/status.h"
 
 namespace kudu {
@@ -74,24 +75,62 @@ class LogIndex : public RefCountedThreadSafe<LogIndex> {
   // earlier entries.
   void GC(int64_t min_index_to_retain);
 
-  Status OpenAllChunksOnStartup(Env *env);
+  // Number of chunks to mmap. The default value is 3.
+  void SetNumMmapChunks(int64_t num_chunks);
+
+  // Only to be used in tests. It is dangerous to change number of entries per
+  // chunk on a running instance or an instance which already has created a few
+  // index chunks. This changes the on-disk format of the chunk file rendering
+  // any previously created chunks unreadable
+  void SetNumEntriesPerChunkForTest(int64_t entries);
+
+  // Opens all chunks files found in the file system and inserts the chunk into
+  // 'open_chunks_' map. Also mmaps 'kNumChunksToMmap' latest chunks. Also
+  // initializes the metric counter ''mmap_for_reads_'
+  Status OpenAllChunksOnStartup(
+      Env *env, const scoped_refptr<MetricEntity>& metric_entity);
 
  private:
   friend class RefCountedThreadSafe<LogIndex>;
+
   ~LogIndex();
 
   class IndexChunk;
 
-  Status OpenAndInsertChunk(int64_t chunk_idx,
-      scoped_refptr<IndexChunk>* chunk);
+  // Opens the file corresponding to 'chunk_idx' and inserts it into
+  // 'open_chunks_'
+  Status OpenAndInsertChunk(
+      int64_t chunk_idx,
+      scoped_refptr<IndexChunk>* chunk,
+      bool should_mmap);
 
   // Open the on-disk chunk with the given index.
   // Note: 'chunk_idx' is the index of the index chunk, not the index of a log _entry_.
-  Status OpenChunk(int64_t chunk_idx, scoped_refptr<IndexChunk>* chunk);
+  Status OpenChunk(
+      int64_t chunk_idx, 
+      scoped_refptr<IndexChunk>* chunk);
+
+  // mmaps the file corresponding to chunk. The caller should hold
+  // 'open_chunks_lock_' and 'chunk' should have already been opened and
+  // inserted into 'open_chunks_' map.
+  //
+  // At any given time, the instance can only mmap a max of 'kChunksToMmap'
+  // chunks. Hence, this method might have to 'evict' and unmap a chunk before
+  // it can mmap the provided 'chunk'. The victim is chosen to be the oldest
+  // chunk that is mmapped (i.e the chunk that has the lowest chunk_idx). The
+  // rationale is that writes only append an entry to the latest chunk and hence
+  // it should always be mmapped. A side effect of such an eviction policy is
+  // that the most lagging peer is always the victim which will delay that peer
+  // from catching up sooner. One way to void this is to configure
+  // 'kChunksToMMap' to be equal to the number of peers in the ring and each
+  // peer have its own slot for 'mmapping' an index chunk (but this strategy is
+  // not implemented yet). Check 'kChunksToMmap' for more details
+  Status MmapChunk(scoped_refptr<IndexChunk>* chunk);
 
   // Return the index chunk which contains the given log index.
   // If 'create' is true, creates it on-demand. If 'create' is false, and
   // the index chunk does not exist, returns NotFound.
+  // Whenever a new chunk is created, it also mmaps the chunk
   Status GetChunkForIndex(int64_t log_index, bool create,
                           scoped_refptr<IndexChunk>* chunk);
 
@@ -108,6 +147,42 @@ class LogIndex : public RefCountedThreadSafe<LogIndex> {
   // Protected by open_chunks_lock_
   typedef std::map<int64_t, scoped_refptr<IndexChunk> > ChunkMap;
   ChunkMap open_chunks_;
+
+  // Number of index chunks to mmap for faster access. The default value is 3.
+  //
+  // The latest index chunks (ones with the highest chunk_idx) is always
+  // mmapped. This is required for better write performance. A write
+  // 'operation' into the log will always append an entry to the latest index
+  // chunk - i.e index chunk is an append only operation (unless when an OpId
+  // is trimmed from the replication log)
+  //
+  // A lagging peer that is trying to catch up might trigger a read operation
+  // from an index chunk that is unmapped. One of the existing mmapped chunk
+  // is unmapped to make space for dynamically map an index chunk for read
+  // operation. The victim chunk that gets unmapped is the oldest index chunk
+  // (so that writes are not effected)
+  //
+  // It might so happen that a set of lagging peers will thrash each other. For
+  // example, follower1 is trying to catchup OpId(1, 1), follower2 is trying to
+  // cathcup OpId(1, 1000001) and follower3 is trying to catchup (1, 2000001).
+  // In this case, each follower will thrash and end up mapping/unmapping chunks
+  // rapidly to read from the replication log. This is a very unlikely scenario
+  // (since there should be peers lagging across OpIds that are multiple million
+  // trxs away from each other).
+  //
+  // On followers, learners and any other nodes in the ring that are not
+  // expected to serve read requests, this could be configured to value of 1 or
+  // 2 (the premise being that writes only 'append' to the latest chunk)
+  int64_t kNumChunksToMmap = 3;
+
+  // Number of entries per index chunk.
+  // WARNING: this is made 'configurable' only for tests. This should never be
+  // modified once a ring is created
+  int64_t kEntriesPerIndexChunk = 1000000;
+
+  // Counter tracking number of times an index chunk had to be mmapped
+  // dynamically for a read operation
+  scoped_refptr<Counter> mmap_for_reads_;
 
   DISALLOW_COPY_AND_ASSIGN(LogIndex);
 };


### PR DESCRIPTION
Summary:
kuduraft maintains dense index file for random read of replication log. This
dense index files are implemented as index chunks. Each entry in the index chunk
contains the offset of a particular OpId in the replication log. For faster
access (reads and writes), these index chunks are mmapped. By default, each index
chunk is configured to have 1000000 entries (i.e 1 million OpId entries) and the
size of an index chunk is 24MB. These index chunk files are deleted when the
replication log files are purged. Upstream kudu has GC thread which purges
replication logs and also the index chunk files periodically, but it is disabled
in kuduraft fork (to give more control of purging of replication logs to the
upper layer).

However, this could lead to scenarios where hundreds of index chunks could get
mmaped leading to substantial increase in rss memory consumption by the process
until the replication logs are purged. This diff tries to address the problem
by having the ability to dynamically mmap and unmap the required index chunks
and not tying the mmap/unmap of the chunks to the open/deletes of the
underlying chunk file.

The max number of entries that could be mmapped at any given time is
configurable through 'kNumChunksToMmap'. The latest chunk is always pinned
(i.e always mmapped) - the rationale here is that writes always happen to the
latest chunk. If a lagging peer asks for an OpId in an index chunk that is
currently not mmapped, then the index chunk is mmapped dynamically. A 'victim'
chunk might have to be unmappedbefore this-and the victim is always the oldest
chunk that is still mmapped.

Some observations:
1. Chunks are only 'read' when a peer requests for an OpId that has fallen off
of the leader's log-cache (and most likely the peer is lagging). Given this,
'kNumChunksToMmap' can be configured to a very low value (1 or 2) on peers which
will never serve read requests (primarily every peer other than the leader). In
future, we could even enhance this so that kuduraft automatically adjusts this
on every leader election/config-change
2. If there are multiple peers that are lagging across OpIds that are a million
OpIds away from each other, then it could lead to thrashing (frequent and rapid
mmap and unmap of index chunk files). For example, follower1 is trying to catch
up OpId (1, 1), follower2 is catching up (1, 1000001), follower3 is catching up
OpId (1, 2000001) and so on. However, this seems like a rear scenario. One
solution could be to configure each peer to have its own 'slot' in the leader's
mmapped index chunk. This could be enahnced in future if needed. Obviously all
of this will not be needed if the ultimate goal is to move away from dense index
files to sparse index files.
3. upstream kudu seems to have moved away from mmapping index chunk files and
rely on pread/pwrite to do random access of the index chunk. This is done
through interfaces in env_. We could try to incorporate it whenever we rebase
onto latest upstream kudu
4. Even though the chunk files are dynamically 'unmapped', the underlying file
itself is not closed and continues to be tracked through 'open_chunks_' (as was
happening previously). The file is only closed when it gets GCd by upper layers
(and deleted) as was happening earlier. This might show up as the process
leaking file descriptors, but is not actually a leak since the files will
eventually be closed on GC

Test Plan:
unit tests on fbcode and integration tests with mtr

Reviewers: arahut

Subscribers:

Tasks:

Tags: