### PR TITLE
Reducing logging of some messages to throttled mode

### DIFF
--- a/src/kudu/consensus/consensus_peers.cc
+++ b/src/kudu/consensus/consensus_peers.cc
@@ -491,7 +491,7 @@ void Peer::ProcessResponseError(const Status& status) {
   }
 #endif
 
-  LOG_WITH_PREFIX_UNLOCKED(WARNING) << "Couldn't send request to peer " << peer_pb_.permanent_uuid()
+  KLOG_EVERY_N_SECS(WARNING, 60) << LogPrefixUnlocked() << "Couldn't send request to peer " << peer_pb_.permanent_uuid()
       << " for tablet " << tablet_id_ << "."
       << resp_err_info
       << " Status: " << status.ToString() << "."
@@ -513,7 +513,7 @@ void Peer::Close() {
     if (closed_) return;
     closed_ = true;
   }
-  LOG_WITH_PREFIX_UNLOCKED(INFO) << "Closing peer: " << peer_pb_.permanent_uuid();
+  KLOG_EVERY_N(INFO, 5) << LogPrefixUnlocked() << "Closing peer: " << peer_pb_.permanent_uuid();
 
   queue_->UntrackPeer(peer_pb_.permanent_uuid());
 }


### PR DESCRIPTION
Summary: When instances become unhealthy append entries can fail.
Printing this message for each round is not useful. Instead in
this patch we throttle it to once per 60 seconds. Even at this rate
1400 messages per day is possible on primary, but not too bad.

Test Plan: Ran a unit-test with RejectAppendEntries and here is the
Before/After

After

W1024 20:56:17.280287 1842087 consensus_peers.cc:494] T 00000000000000000000000000000000 P 00000000-0000-0000-0000-000000000000 -> Peer 22222222-2222-2222-2222-222222222222 (2401:db00:eef0:1120:3520:0000:1c05:df80:19922): Couldn't send request to peer 22222222-2222-2222-2222-222222222222 for tablet 00000000000000000000000000000000. Status: Illegal state: Rejected: --follower_reject_update_consensus_requests is set to true.. Retrying in the next heartbeat period. Already tried 70 times.
W1024 20:57:17.330436 1842090 consensus_peers.cc:494] T 00000000000000000000000000000000 P 00000000-0000-0000-0000-000000000000 -> Peer 11111111-1111-1111-1111-111111111111 (2401:db00:eef0:1120:3520:0000:1c05:df80:19921): Couldn't send request to peer 11111111-1111-1111-1111-111111111111 for tablet 00000000000000000000000000000000. Status: Illegal state: Rejected: --follower_reject_update_consensus_requests is set to true.. Retrying in the next heartbeat period. Already tried 193 times.

Messages are spaced out by 60 seconds

Before

W1024 21:03:58.099913 1880378 consensus_peers.cc:494] T 00000000000000000000000000000000 P 00000000-0000-0000-0000-000000000000 -> Peer 11111111-1111-1111-1111-111111111111 (2401:db00:eef0:1120:3520:0000:1c05:df80:19951): Couldn't send request to peer 11111111-1111-1111-1111-111111111111 for tablet 00000000000000000000000000000000. Status: Illegal state: Rejected: --follower_reject_update_consensus_requests is set to true.. Retrying in the next heartbeat period. Already tried 1 times.
W1024 21:03:58.243330 1880378 consensus_peers.cc:494] T 00000000000000000000000000000000 P 00000000-0000-0000-0000-000000000000 -> Peer 22222222-2222-2222-2222-222222222222 (2401:db00:eef0:1120:3520:0000:1c05:df80:19952): Couldn't send request to peer 22222222-2222-2222-2222-222222222222 for tablet 00000000000000000000000000000000. Status: Illegal state: Rejected: --follower_reject_update_consensus_requests is set to true.. Retrying in the next heartbeat period. Already tried 1 times.
W1024 21:03:58.602859 1880378 consensus_peers.cc:494] T 00000000000000000000000000000000 P 00000000-0000-0000-0000-000000000000 -> Peer 11111111-1111-1111-1111-111111111111 (2401:db00:eef0:1120:3520:0000:1c05:df80:19951): Couldn't send request to peer 11111111-1111-1111-1111-111111111111 for tablet 00000000000000000000000000000000. Status: Illegal state: Rejected: --follower_reject_update_consensus_requests is set to true.. Retrying in the next heartbeat period. Already tried 2 times.
W1024 21:03:58.866850 1880378 consensus_peers.cc:494] T 00000000000000000000000000000000 P 00000000-0000-0000-0000-000000000000 -> Peer 22222222-2222-2222-2222-222222222222 (2401:db00:eef0:1120:3520:0000:1c05:df80:19952): Couldn't send request to peer 22222222-2222-2222-2222-222222222222 for tablet 00000000000000000000000000000000 ...

Reviewers: bhatvinay, yichenshen

Subscribers:

Tasks:

Tags: