### PR TITLE
Add logtailer server port to PeerAttrsPB for BLS peers

### DIFF
--- a/src/kudu/consensus/metadata.proto
+++ b/src/kudu/consensus/metadata.proto
@@ -42,6 +42,9 @@ message RaftPeerAttrsPB {
 
   // Geographic region of the raft server.
   optional string region = 4;
+  
+  // The port on which the logtailer server for a BLS peer is running
+  optional int32 logtailer_server_port = 5 [ default = 0 ];
 }
 
 // Report on a replica's (peer's) health.


### PR DESCRIPTION
Summary:
The logtailer server port will be set and persisted in topology config and config change events. This port is used to identify already existing peers that are not backed by a database so that we do not end up creating duplicate services for them.

Test Plan:
Tested with plugin in fbcode

Reviewers: arahut, yichenshen, vinaybhat

Subscribers:

Tasks:

Tags: