### PR TITLE
Squelching some log messages which are overwhelming logs

### DIFF
--- a/src/kudu/consensus/consensus_queue.cc
+++ b/src/kudu/consensus/consensus_queue.cc
@@ -772,8 +772,10 @@ Status PeerMessageQueue::RequestForPeer(const string& uuid,
   if (request->ops_size() > 0) {
     int64_t last_op_sent = request->ops(request->ops_size() - 1).id().index();
     if (last_op_sent < request->committed_index()) {
-      KLOG_EVERY_N_SECS_THROTTLER(INFO, 3, *peer_copy.status_log_throttler, "lagging")
-          << LogPrefixUnlocked() << "Peer " << uuid << " is lagging by at least "
+      // Will use metrics to cover this and alarm on it, otherwise it can overwhelm
+      // logs
+      VLOG_WITH_PREFIX_UNLOCKED(2)
+          << "Peer " << uuid << " is lagging by at least "
           << (request->committed_index() - last_op_sent)
           << " ops behind the committed index " << THROTTLE_MSG;
     }


### PR DESCRIPTION
Summary:
1. Failing upstream (in say mysql raft plugin) for Start Follower
Transaction is expected on rotate event

2. Lagging in non-local regions for flexi-raft is expected as
   commits don't ned to wait for them. How far they lag can be
   handled via lag metrics instead of overwhelming logs.

Test Plan: build is test

Reviewers: bhatvinay, yichenshen, yashtc

Subscribers:

Tasks:

Tags: