### PR TITLE
[kuduraft] compression of messages in log-cache

### DIFF
--- a/src/kudu/consensus/consensus.proto
+++ b/src/kudu/consensus/consensus.proto
@@ -32,6 +32,7 @@ import "kudu/consensus/metadata.proto";
 import "kudu/consensus/opid.proto";
 import "kudu/consensus/replica_management.proto";
 import "kudu/rpc/rpc_header.proto";
+import "kudu/util/compression/compression.proto";
 // NOTE: anirbanr-fb
 //import "kudu/tablet/metadata.proto";
 //import "kudu/tablet/tablet.proto";
@@ -254,6 +255,13 @@ message ChangeConfigResponsePB {
 // Payload for replicate message (for write requests)
 message WritePayloadPB {
   optional bytes payload = 1;
+
+  // Compression codec used to compress payload
+  optional CompressionType compression_codec = 2 [ default = NO_COMPRESSION ];
+
+  // Uncompressed size of payload. Should be present when
+  // compression_codec != NO_COMPRESSION
+  optional int64 uncompressed_size = 3;
 }
 
 // A Replicate message, sent to replicas by leader to indicate this operation must

--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -4024,6 +4024,11 @@ void RaftConsensus::HandleProxyRequest(const ConsensusRequestPB* request,
   context->RespondSuccess();
 }
 
+Status RaftConsensus::SetCompressionCodec(const std::string& codec) {
+  LockGuard l(lock_);
+  return queue_->log_cache()->SetCompressionCodec(codec);
+}
+
 ////////////////////////////////////////////////////////////////////////
 // ConsensusBootstrapInfo
 ////////////////////////////////////////////////////////////////////////

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -577,6 +577,9 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
                                      const StdStatusCallback& client_cb,
                                      const Status& status);
 
+  // Set the compression codec to be used to compress ReplicateMsg payload
+  Status SetCompressionCodec(const std::string& codec);
+
  protected:
   RaftConsensus(ConsensusOptions options,
                 RaftPeerPB local_peer_pb,


### PR DESCRIPTION
Summary:
Adds compression support in LogCache layer. Existing compression utilities of
kudu (which are exposed as singletons) are reused.

Some notable design aspects:
1. The idea is to compress only once. So, compressing entries in log-cache
ensures that all followers automatically read compressed entries without having
to pay the cost of compressing multiple times
2. Only messages with op_type = WRITE_OP_EXT is compressed. This is due to some
dependency on the upper layer and also the fact that
NO_OP/ROTATE_OP/CONFIG_CHANGE_OP are comparitively smaller in size and do not
gain much by compression
3. #1 essentially means that compression happens in-line along the commit path.
Other possible place for compressing entries is LogCache::ReadOps() - the first
peer that calls into ReadOps() could compress the entry in the cache. We could
pursue this (if needed)
4. Note that a new compressed entry is added to LogCache. The design of the LogCache
itself ensures that this entry satys in the cache until the entry is either
replicated to all peers (based on all_replicated_index) OR a surge of
AppendOperations() [writes] overwhelm the cache leading to early eviction.
PendingRounds also keeps a reference to the uncompressed message being replicated
which might stay around (increasing the memory consumption slightly). But PendingRounds keeps
a reference only till the round is deemed committed (committed_index), hence the
increased memory consumtion should be trivial (to only a few 'pending' trxs)

Some things that are not handled:
1. A lagging follower might have to read entries directly from log. These
messages are not compressed. This needs to be implemented in the second version
after gathering some data
2. Chunking or streaming compression is not implemented. This essentially means
that the entire buffer needed for compression has to be preallocated AND
compressing subsequent messages do not really benifit from the current msg's
compression ratio/strategy. Streaming compression, if needed is best implemented
outside of LogCache, but is not thought through and implemented yet.
3. Existing singleton classes in kudu are reused for this first version. This
supports ZLIB/SNAPPY/LZ4. The support for now is trivial without ability to
configure compression levels/windows/streaming etc. This needs to be enhanced in
future.

Test Plan:
new tests added in fbcode/mtr

Reviewers: arahut

Subscribers:

Tasks:

Tags: