### PR TITLE
[kuduraft] no load shedding in RequestVote() for LMP

### DIFF
--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -1839,7 +1839,7 @@ Status RaftConsensus::RequestVote(const VoteRequestPB* request,
   // takes place between requests.
   // Lock ordering: update_lock_ must be acquired before lock_.
   std::unique_lock<simple_spinlock> update_guard(update_lock_, std::defer_lock);
-  if (FLAGS_enable_leader_failure_detection) {
+  if (FLAGS_enable_leader_failure_detection && !request->ignore_live_leader()) {
     update_guard.try_lock();
   } else {
     // If failure detection is not enabled, then we can't just reject the vote,


### PR DESCRIPTION
Summary:
RequestVote() rpc is rejected if the replica is already servicing another request.
This  is a crude load shedding mechanism to avoid overwhelming rpc queue.

For LMP case, this can cause problems and increase downtime. Further, with FR,
votes from leader region is really important to avoid multiple elections and
terms without a leader (further increasing downtime).

This PR tries to fix the problem:
When an explicit request is made to start an election, the RequestVotePB will
have ignore_live_leader set. Based on this, RequestVote() will block trying to
acquire "update_lock_"  instead of rejecting the vote. update_lock_ will soon be
free and RequestVote() can make forward progress.

Test Plan:
next rpm

Reviewers: arahut

Subscribers:

Tasks:

Tags: