### PR TITLE
Snooze failure detection for a randomized timeout

### DIFF
--- a/src/kudu/consensus/consensus_meta.cc
+++ b/src/kudu/consensus/consensus_meta.cc
@@ -143,6 +143,14 @@ bool ConsensusMetadata::IsMemberInConfig(const string& uuid,
   return IsRaftConfigMember(uuid, GetConfig(type));
 }
 
+bool ConsensusMetadata::IsMemberInConfigWithDetail(
+    const std::string& uuid,
+    RaftConfigState type,
+    std::string *hostname_port) {
+  DFAKE_SCOPED_RECURSIVE_LOCK(fake_lock_);
+  return IsRaftConfigMemberWithDetail(uuid, GetConfig(type), hostname_port);
+}
+
 int ConsensusMetadata::CountVotersInConfig(RaftConfigState type) {
   DFAKE_SCOPED_RECURSIVE_LOCK(fake_lock_);
   return CountVoters(GetConfig(type));

--- a/src/kudu/consensus/consensus_meta.h
+++ b/src/kudu/consensus/consensus_meta.h
@@ -93,6 +93,10 @@ class ConsensusMetadata : public RefCountedThreadSafe<ConsensusMetadata> {
   // local Raft config.
   bool IsMemberInConfig(const std::string& uuid, RaftConfigState type);
 
+  bool IsMemberInConfigWithDetail(const std::string& uuid,
+      RaftConfigState type,
+      std::string *hostname_port);
+
   // Returns a count of the number of voters in the specified local Raft
   // config.
   int CountVotersInConfig(RaftConfigState type);

--- a/src/kudu/consensus/quorum_util.cc
+++ b/src/kudu/consensus/quorum_util.cc
@@ -59,6 +59,22 @@ bool IsRaftConfigMember(const std::string& uuid, const RaftConfigPB& config) {
   return false;
 }
 
+bool IsRaftConfigMemberWithDetail(const std::string& uuid,
+    const RaftConfigPB& config, std::string *hostname_port) {
+  for (const RaftPeerPB& peer : config.peers()) {
+    if (peer.permanent_uuid() == uuid) {
+      const ::kudu::HostPortPB& host_port = peer.last_known_addr();
+      if (!peer.hostname().empty()) {
+        *hostname_port = Substitute("$0:$1", peer.hostname(), host_port.port());
+      } else {
+        *hostname_port = Substitute("[$0]:$1", host_port.host(), host_port.port());
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
 bool IsRaftConfigVoter(const std::string& uuid, const RaftConfigPB& config) {
   for (const RaftPeerPB& peer : config.peers()) {
     if (peer.permanent_uuid() == uuid) {

--- a/src/kudu/consensus/quorum_util.h
+++ b/src/kudu/consensus/quorum_util.h
@@ -49,6 +49,8 @@ bool IsRaftConfigMember(const std::string& uuid, const RaftConfigPB& config);
 bool IsRaftConfigVoter(const std::string& uuid, const RaftConfigPB& config);
 bool GetRaftConfigMemberRegion(const std::string& uuid, const RaftConfigPB& config,
     bool *is_voter, std::string *region);
+bool IsRaftConfigMemberWithDetail(const std::string& uuid,
+    const RaftConfigPB& config, std::string *hostname_port);
 
 // Whether the specified Raft role is attributed to a peer which can participate
 // in leader elections.


### PR DESCRIPTION
Summary: This is to be avoid collisions during voting and being more
in line with Raft Thesis and LogCabin implementation. When a FOLLOWER
gets a UpdateReplica messge it snoozes its failure detector for a
randomized period from 1X - 2X of MinimumElectionTimeout. It will still
allow votes after MinElectionTimeout. This will allow another voter to
get votes from this FOLLOWER after a MinElectionTimeout. i.e. this
FOLLOWER tries to keep ring stable for 1 timeout, but also randomizes
its solicitation so that it doesn't collide with other candidates.

Also improved logging to have better messages distinguishing
pre-election/election

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: