### PR TITLE
Expose kudu pbc dump tool as library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1481,7 +1481,7 @@ add_subdirectory(src/kudu/security)
 add_subdirectory(src/kudu/server)
 #add_subdirectory(src/kudu/tablet)
 #add_subdirectory(src/kudu/thrift)
-#add_subdirectory(src/kudu/tools)
+add_subdirectory(src/kudu/tools)
 add_subdirectory(src/kudu/tserver)
 add_subdirectory(src/kudu/util)
 

--- a/src/kudu/tools/CMakeLists.txt
+++ b/src/kudu/tools/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(tool_proto
 target_link_libraries(tool_proto
   kudu_common_proto
   protobuf
-  tablet_proto
+#  tablet_proto
   wire_protocol_proto)
 
 #######################################
@@ -40,22 +40,22 @@ target_link_libraries(tool_proto
 
 add_library(kudu_tools_util
   color.cc
-  data_gen_util.cc
+#  data_gen_util.cc
   diagnostics_log_parser.cc
   tool_action.cc
   tool_action_common.cc
 )
 target_link_libraries(kudu_tools_util
-  cfile
+#  cfile
   consensus
   gutil
-  kudu_client
+#  kudu_client
   kudu_common
   kudu_fs
   kudu_util
   log
   server_process
-  tablet
+#  tablet
   tool_proto
   ${KUDU_BASE_LIBS}
 )
@@ -64,79 +64,81 @@ target_link_libraries(kudu_tools_util
 # ksck
 #######################################
 
-add_library(ksck
-    ksck.cc
-    ksck_checksum.cc
-    ksck_remote.cc
-    ksck_results.cc
-)
-target_link_libraries(ksck
-  consensus
-  kudu_tools_util
-  master
-  master_proto
-  server_base_proto
-  tserver_proto
-  tserver_service_proto
-  ${KUDU_BASE_LIBS}
-)
+#add_library(ksck
+#    ksck.cc
+#    ksck_checksum.cc
+#    ksck_remote.cc
+#    ksck_results.cc
+#)
+#target_link_libraries(ksck
+#  consensus
+#  kudu_tools_util
+#  master
+#  master_proto
+#  server_base_proto
+#  tserver_proto
+#  tserver_service_proto
+#  ${KUDU_BASE_LIBS}
+#)
 
 #######################################
 # kudu_tools_rebalance
 #######################################
 
-add_library(kudu_tools_rebalance
-  rebalancer.cc
-  rebalance_algo.cc
-  tool_replica_util.cc
-)
-target_link_libraries(kudu_tools_rebalance
-  ksck
-  kudu_common
-  ${KUDU_BASE_LIBS}
-)
+#add_library(kudu_tools_rebalance
+#  rebalancer.cc
+#  rebalance_algo.cc
+#  tool_replica_util.cc
+#)
+#target_link_libraries(kudu_tools_rebalance
+#  ksck
+#  kudu_common
+#  ${KUDU_BASE_LIBS}
+#)
 
 #######################################
 # kudu
 #######################################
 
-add_executable(kudu
-  tool_action_cluster.cc
-  tool_action_diagnose.cc
-  tool_action_fs.cc
-  tool_action_hms.cc
-  tool_action_local_replica.cc
-  tool_action_master.cc
+#add_executable(kudu
+add_library(kudu_tool
+#  tool_action_cluster.cc
+#  tool_action_diagnose.cc
+#  tool_action_fs.cc
+#  tool_action_hms.cc
+#  tool_action_local_replica.cc
+#  tool_action_master.cc
   tool_action_pbc.cc
-  tool_action_perf.cc
-  tool_action_remote_replica.cc
-  tool_action_table.cc
-  tool_action_tablet.cc
-  tool_action_test.cc
-  tool_action_tserver.cc
-  tool_action_wal.cc
+#  tool_action_perf.cc
+#  tool_action_remote_replica.cc
+#  tool_action_table.cc
+#  tool_action_tablet.cc
+#  tool_action_test.cc
+#  tool_action_tserver.cc
+#  tool_action_wal.cc
   tool_main.cc
 )
-target_link_libraries(kudu
-  ${SANITIZER_OPTIONS_OVERRIDE}
-  ${KRB5_REALM_OVERRIDE}
+target_link_libraries(kudu_tool
+#  ${SANITIZER_OPTIONS_OVERRIDE}
+#  ${KRB5_REALM_OVERRIDE}
   clock
   consensus
   gutil
   krpc
-  ksck
-  kudu_client
-  kudu_client_test_util
+#  ksck
+#  kudu_client
+#  kudu_client_test_util
   kudu_common
   kudu_fs
-  kudu_tools_rebalance
+#  kudu_tools_rebalance
+  kudu_tools_util
   kudu_util
   log
-  master
-  mini_cluster
-  tablet
+#  master
+#  mini_cluster
+#  tablet
   tool_proto
-  tserver
+#  tserver
   ${KUDU_BASE_LIBS}
 )
 
@@ -144,41 +146,41 @@ target_link_libraries(kudu
 # kudu_tools_test_util
 #######################################
 
-add_library(kudu_tools_test_util
-  tool_test_util.cc
-)
-target_link_libraries(kudu_tools_test_util
-  kudu_util
-)
+#add_library(kudu_tools_test_util
+#  tool_test_util.cc
+#)
+#target_link_libraries(kudu_tools_test_util
+#  kudu_util
+#)
 
 #######################################
 # Unit tests
 #######################################
 
-SET_KUDU_TEST_LINK_LIBS(
-  itest_util
-  ksck
-  kudu_hms
-  kudu_tools_rebalance
-  kudu_tools_test_util
-  kudu_tools_util
-  mini_cluster)
-ADD_KUDU_TEST(diagnostics_log_parser-test)
-ADD_KUDU_TEST(ksck-test)
-ADD_KUDU_TEST(ksck_remote-test PROCESSORS 3)
-ADD_KUDU_TEST(kudu-admin-test
-  NUM_SHARDS 8 PROCESSORS 3)
-ADD_KUDU_TEST_DEPENDENCIES(kudu-admin-test
-  kudu)
-ADD_KUDU_TEST(kudu-tool-test
-  NUM_SHARDS 4 PROCESSORS 3
-  DATA_FILES testdata/sample-diagnostics-log.txt testdata/bad-diagnostics-log.txt
-  DATA_FILES testdata/first_argument.sh)
-ADD_KUDU_TEST_DEPENDENCIES(kudu-tool-test
-  kudu)
-ADD_KUDU_TEST(kudu-ts-cli-test)
-ADD_KUDU_TEST_DEPENDENCIES(kudu-ts-cli-test
-  kudu)
-ADD_KUDU_TEST(rebalance-test)
-ADD_KUDU_TEST(rebalance_algo-test)
-ADD_KUDU_TEST(tool_action-test)
+#SET_KUDU_TEST_LINK_LIBS(
+#  itest_util
+#  ksck
+#  kudu_hms
+#  kudu_tools_rebalance
+#  kudu_tools_test_util
+#  kudu_tools_util
+#  mini_cluster)
+#ADD_KUDU_TEST(diagnostics_log_parser-test)
+#ADD_KUDU_TEST(ksck-test)
+#ADD_KUDU_TEST(ksck_remote-test PROCESSORS 3)
+#ADD_KUDU_TEST(kudu-admin-test
+#  NUM_SHARDS 8 PROCESSORS 3)
+#ADD_KUDU_TEST_DEPENDENCIES(kudu-admin-test
+#  kudu)
+#ADD_KUDU_TEST(kudu-tool-test
+#  NUM_SHARDS 4 PROCESSORS 3
+#  DATA_FILES testdata/sample-diagnostics-log.txt testdata/bad-diagnostics-log.txt
+#  DATA_FILES testdata/first_argument.sh)
+#ADD_KUDU_TEST_DEPENDENCIES(kudu-tool-test
+#  kudu)
+#ADD_KUDU_TEST(kudu-ts-cli-test)
+#ADD_KUDU_TEST_DEPENDENCIES(kudu-ts-cli-test
+#  kudu)
+#ADD_KUDU_TEST(rebalance-test)
+#ADD_KUDU_TEST(rebalance_algo-test)
+#ADD_KUDU_TEST(tool_action-test)

--- a/src/kudu/tools/color.cc
+++ b/src/kudu/tools/color.cc
@@ -43,7 +43,7 @@ static bool ValidateColorFlag(const char* flagname, const std::string& value) {
   LOG(ERROR) << "option 'color' expects \"always\", \"auto\", or \"never\"";
   return false;
 }
-static bool dummy = google::RegisterFlagValidator(
+static bool dummy = gflags::RegisterFlagValidator(
     &FLAGS_color, &ValidateColorFlag);
 
 

--- a/src/kudu/tools/tool.proto
+++ b/src/kudu/tools/tool.proto
@@ -21,8 +21,8 @@ option java_package = "org.apache.kudu.tools";
 
 import "kudu/common/common.proto";
 import "kudu/common/wire_protocol.proto";
-import "kudu/tablet/metadata.proto";
-import "kudu/tablet/tablet.proto";
+//import "kudu/tablet/metadata.proto";
+//import "kudu/tablet/tablet.proto";
 
 // Creates a new ExternalMiniCluster.
 //
@@ -44,7 +44,7 @@ message CreateClusterRequestPB {
 
   // Whether or not to create a Hive Metastore, and/or enable Kudu Hive
   // Metastore integration.
-  optional HmsMode hms_mode = 7;
+  //optional HmsMode hms_mode = 7;
 
   // The directory where the cluster's data and logs should be placed.
   optional string cluster_root = 4;
@@ -270,8 +270,8 @@ message KsckReplicaSummaryPB {
   optional bool ts_healthy = 3;
   optional bool is_leader = 4;
   optional bool is_voter = 5;
-  optional tablet.TabletStatePB state = 6;
-  optional tablet.TabletStatusPB status_pb = 7;
+  //optional tablet.TabletStatePB state = 6;
+  //optional tablet.TabletStatusPB status_pb = 7;
   optional KsckConsensusStatePB consensus_state = 8;
 }
 

--- a/src/kudu/tools/tool_action.cc
+++ b/src/kudu/tools/tool_action.cc
@@ -48,7 +48,7 @@ namespace tools {
 namespace {
 
 string FakeDescribeOneFlag(const ActionArgsDescriptor::Arg& arg) {
-  string res = google::DescribeOneFlag({
+  string res = gflags::DescribeOneFlag({
     arg.name,        // name
     "string",        // type
     arg.description, // description
@@ -232,7 +232,7 @@ ActionBuilder& ActionBuilder::AddOptionalParameter(string param,
 #ifndef NDEBUG
   // Make sure this gflag exists.
   string option;
-  DCHECK(google::GetCommandLineOption(param.c_str(), &option)) << "unknown option: " << param;
+  DCHECK(gflags::GetCommandLineOption(param.c_str(), &option)) << "unknown option: " << param;
 #endif
   args_.optional.emplace_back(ActionArgsDescriptor::Flag({ std::move(param),
                                                            std::move(default_value),
@@ -275,8 +275,8 @@ string Action::BuildHelp(const vector<Mode*>& chain,
     desc_msg += "\n";
   }
   for (const auto& param : args_.optional) {
-    google::CommandLineFlagInfo gflag_info =
-        google::GetCommandLineFlagInfoOrDie(param.name.c_str());
+    gflags::CommandLineFlagInfo gflag_info =
+        gflags::GetCommandLineFlagInfoOrDie(param.name.c_str());
 
     if (param.description) {
       gflag_info.description = *param.description;
@@ -299,7 +299,7 @@ string Action::BuildHelp(const vector<Mode*>& chain,
       }
       usage_msg += Substitute(" [-$0=<$1>]", param.name, noun);
     }
-    desc_msg += google::DescribeOneFlag(gflag_info);
+    desc_msg += gflags::DescribeOneFlag(gflag_info);
     desc_msg += "\n";
   }
   if (mode == USAGE_ONLY) {
@@ -353,8 +353,8 @@ string Action::BuildHelpXML(const vector<Mode*>& chain) const {
   }
 
   for (const auto& o : args().optional) {
-    google::CommandLineFlagInfo gflag_info =
-        google::GetCommandLineFlagInfoOrDie(o.name.c_str());
+    gflags::CommandLineFlagInfo gflag_info =
+        gflags::GetCommandLineFlagInfoOrDie(o.name.c_str());
 
     if (o.description) {
       gflag_info.description = *o.description;
@@ -395,9 +395,9 @@ string Action::BuildHelpXML(const vector<Mode*>& chain) const {
 void Action::SetOptionalParameterDefaultValues() const {
   for (const auto& param : args_.optional) {
     if (param.default_value) {
-      google::SetCommandLineOptionWithMode(param.name.c_str(),
+      gflags::SetCommandLineOptionWithMode(param.name.c_str(),
                                            param.default_value->c_str(),
-                                           google::FlagSettingMode::SET_FLAGS_DEFAULT);
+                                           gflags::FlagSettingMode::SET_FLAGS_DEFAULT);
     }
   }
 }

--- a/src/kudu/tools/tool_action_common.h
+++ b/src/kudu/tools/tool_action_common.h
@@ -23,7 +23,6 @@
 #include <string>
 #include <vector>
 
-#include "kudu/client/shared_ptr.h"
 #include "kudu/gutil/macros.h"
 #include "kudu/gutil/port.h"
 #include "kudu/gutil/ref_counted.h"
@@ -38,14 +37,6 @@ namespace kudu {
 
 class MonoDelta;
 class faststring;
-
-namespace client {
-class KuduClient;
-} // namespace client
-
-namespace master {
-class MasterServiceProxy;
-} // namespace master
 
 namespace rpc {
 class RpcController;
@@ -81,6 +72,7 @@ Status BuildProxy(const std::string& address,
                   uint16_t default_port,
                   std::unique_ptr<ProxyClass>* proxy);
 
+/*
 // Get the current status of the Kudu server running at 'address', storing it
 // in 'status'.
 //
@@ -132,9 +124,7 @@ Status PrintServerFlags(const std::string& address, uint16_t default_port);
 // If 'address' does not contain a port, 'default_port' is used instead.
 Status SetServerFlag(const std::string& address, uint16_t default_port,
                      const std::string& flag, const std::string& value);
-
-// Get the configured master addresses on the most recently connected to leader master.
-std::string GetMasterAddresses(const client::KuduClient& client);
+*/
 
 // Return true if 'str' matches any of the patterns in 'patterns', or if
 // 'patterns' is empty.
@@ -174,35 +164,6 @@ class DataTable {
  private:
   std::vector<std::string> column_names_;
   std::vector<std::vector<std::string>> columns_;
-};
-
-// Wrapper around a Kudu client which allows calling proxy methods on the leader
-// master.
-class LeaderMasterProxy {
- public:
-  LeaderMasterProxy() = default;
-  explicit LeaderMasterProxy(client::sp::shared_ptr<client::KuduClient> client);
-
-  // Initializes the leader master proxy with the given master addresses and timeout.
-  Status Init(const std::vector<std::string>& master_addrs, const MonoDelta& timeout);
-
-  // Initialize the leader master proxy given the provided tool context.
-  //
-  // Uses the required 'master_addresses' option for the master addresses, and
-  // the optional 'timeout_ms' flag to control admin and operation timeouts.
-  Status Init(const RunnerContext& context);
-
-  // Calls a master RPC service method on the current leader master.
-  template<typename Req, typename Resp>
-  Status SyncRpc(const Req& req,
-                 Resp* resp,
-                 const char* func_name,
-                 const boost::function<Status(master::MasterServiceProxy*,
-                                              const Req&, Resp*,
-                                              rpc::RpcController*)>& func);
-
- private:
-  client::sp::shared_ptr<client::KuduClient> client_;
 };
 
 // Facilitates sending and receiving messages with the tool control shell.

--- a/src/kudu/tools/tool_main.cc
+++ b/src/kudu/tools/tool_main.cc
@@ -61,20 +61,20 @@ namespace tools {
 unique_ptr<Mode> RootMode(const string& name) {
   return ModeBuilder(name)
       .Description("Kudu Command Line Tools") // root mode description isn't printed
-      .AddMode(BuildClusterMode())
-      .AddMode(BuildDiagnoseMode())
-      .AddMode(BuildFsMode())
-      .AddMode(BuildHmsMode())
-      .AddMode(BuildLocalReplicaMode())
-      .AddMode(BuildMasterMode())
+      //.AddMode(BuildClusterMode())
+      //.AddMode(BuildDiagnoseMode())
+      //.AddMode(BuildFsMode())
+      //.AddMode(BuildHmsMode())
+      //.AddMode(BuildLocalReplicaMode())
+      //.AddMode(BuildMasterMode())
       .AddMode(BuildPbcMode())
-      .AddMode(BuildPerfMode())
-      .AddMode(BuildRemoteReplicaMode())
-      .AddMode(BuildTableMode())
-      .AddMode(BuildTabletMode())
-      .AddMode(BuildTestMode())
-      .AddMode(BuildTServerMode())
-      .AddMode(BuildWalMode())
+      //.AddMode(BuildPerfMode())
+      //.AddMode(BuildRemoteReplicaMode())
+      //.AddMode(BuildTableMode())
+      //.AddMode(BuildTabletMode())
+      //.AddMode(BuildTestMode())
+      //.AddMode(BuildTServerMode())
+      //.AddMode(BuildWalMode())
       .Build();
 }
 
@@ -219,10 +219,7 @@ int RunTool(int argc, char** argv, bool show_help) {
   return 1;
 }
 
-} // namespace tools
-} // namespace kudu
-
-static bool ParseCommandLineFlags(const char* prog_name) {
+bool ParseCommandLineFlags(const char* prog_name) {
   // Leverage existing helpxml flag to print mode/action xml.
   if (FLAGS_helpxml) {
     kudu::tools::DumpToolXML(prog_name);
@@ -246,11 +243,11 @@ static bool ParseCommandLineFlags(const char* prog_name) {
   return show_help;
 }
 
-int main(int argc, char** argv) {
+int ToolMain(int argc, char** argv) {
   // Disable redaction by default so that user data printed to the console will be shown
   // in full.
-  CHECK_NE("",  google::SetCommandLineOptionWithMode(
-      "redact", "", google::SET_FLAGS_DEFAULT));
+  CHECK_NE("",  gflags::SetCommandLineOptionWithMode(
+      "redact", "", gflags::SET_FLAGS_DEFAULT));
 
   // Hide the regular gflags help unless --helpfull is used.
   //
@@ -264,3 +261,6 @@ int main(int argc, char** argv) {
 
   return kudu::tools::RunTool(argc, argv, show_help);
 }
+
+} // namespace tools
+} // namespace kudu

--- a/src/kudu/tools/tool_main.h
+++ b/src/kudu/tools/tool_main.h
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+namespace kudu {
+namespace tools {
+
+int RunTool(int argc, char** argv, bool show_help);
+bool ParseCommandLineFlags(const char* prog_name);
+int ToolMain(int argc, char** argv);
+
+} // tools
+} // kudu


### PR DESCRIPTION
Summary: This patch makes the kudu dump command, a part of the kudu CLI
tool, build again while keeping all other actions commented out of the
build script. It also exposes the CLI tool as a library instead of an
executable which makes integration with the downstream toolchain easier.

Test Plan: linked against fbcode, tested against cmeta via setup_raft

Reviewers:

Subscribers:

Tasks:

Tags: