### PR TITLE
Adding sample rate information to log messages.

### DIFF
--- a/src/kudu/consensus/consensus_peers.cc
+++ b/src/kudu/consensus/consensus_peers.cc
@@ -491,7 +491,7 @@ void Peer::ProcessResponseError(const Status& status) {
   }
 #endif
 
-  KLOG_EVERY_N_SECS(WARNING, 300) << LogPrefixUnlocked() << "Couldn't send request to peer " << peer_pb_.permanent_uuid()
+  KLOG_EVERY_N_SECS(WARNING, 300) << LogPrefixUnlocked() << "Couldn't send request to peer [EVERY 300 seconds] " << peer_pb_.permanent_uuid()
       << " for tablet " << tablet_id_ << "."
       << resp_err_info
       << " Status: " << status.ToString() << "."
@@ -513,7 +513,7 @@ void Peer::Close() {
     if (closed_) return;
     closed_ = true;
   }
-  KLOG_EVERY_N(INFO, 5) << LogPrefixUnlocked() << "Closing peer: " << peer_pb_.permanent_uuid();
+  KLOG_EVERY_N(INFO, 5) << LogPrefixUnlocked() << "Closing peer [EVERY 5]: " << peer_pb_.permanent_uuid();
 
   queue_->UntrackPeer(peer_pb_.permanent_uuid());
 }

--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -1648,10 +1648,10 @@ Status RaftConsensus::UpdateReplica(const ConsensusRequestPB* request,
             "Soft memory limit exceeded (at %.2f%% of capacity)",
             capacity_pct);
         if (capacity_pct >= FLAGS_memory_limit_warn_threshold_percentage) {
-          KLOG_EVERY_N_SECS(WARNING, 1) << "Rejecting consensus request: " << msg
+          KLOG_EVERY_N_SECS(WARNING, 1) << "Rejecting consensus request [EVERY 1 second]: " << msg
                                         << THROTTLE_MSG;
         } else {
-          KLOG_EVERY_N_SECS(INFO, 1) << "Rejecting consensus request: " << msg
+          KLOG_EVERY_N_SECS(INFO, 1) << "Rejecting consensus request [EVERY 1 second]: " << msg
                                      << THROTTLE_MSG;
         }
         return Status::ServiceUnavailable(msg);

--- a/src/kudu/rpc/connection.cc
+++ b/src/kudu/rpc/connection.cc
@@ -513,7 +513,7 @@ void Connection::ReadHandler(ev::io &watcher, int revents) {
       if (status.posix_code() == ESHUTDOWN) {
         VLOG(1) << ToString() << " shut down by remote end.";
       } else {
-        KLOG_EVERY_N_SECS(WARNING, 300) << ToString() << " recv error: " << status.ToString();
+        KLOG_EVERY_N_SECS(WARNING, 300) << ToString() << " recv error [EVERY 300 seconds]: " << status.ToString();
       }
       reactor_thread_->DestroyConnection(this, status);
       return;
@@ -659,7 +659,7 @@ void Connection::WriteHandler(ev::io &watcher, int revents) {
     last_activity_time_ = reactor_thread_->cur_time();
     Status status = transfer->SendBuffer(*socket_);
     if (PREDICT_FALSE(!status.ok())) {
-      KLOG_EVERY_N_SECS(WARNING, 300) << ToString() << " send error: " << status.ToString();
+      KLOG_EVERY_N_SECS(WARNING, 300) << ToString() << " send error [EVERY 300 seconds]: " << status.ToString();
       reactor_thread_->DestroyConnection(this, status);
       return;
     }

--- a/src/kudu/rpc/negotiation.cc
+++ b/src/kudu/rpc/negotiation.cc
@@ -317,14 +317,14 @@ void Negotiation::RunNegotiation(const scoped_refptr<Connection>& conn,
                        conn->ToString());
     }
     if (is_bad) {
-      KLOG_EVERY_N_SECS(WARNING, 300) << "Failed RPC negotiation. Details: " << msg;
+      KLOG_EVERY_N_SECS(WARNING, 300) << "Failed RPC negotiation. Details [EVERY 300 seconds]: " << msg;
     } else {
       LOG(INFO) << "RPC negotiation tracing enabled. Trace:\n" << msg;
     }
   }
 
   if (conn->direction() == ConnectionDirection::SERVER && s.IsNotAuthorized()) {
-    KLOG_EVERY_N_SECS(WARNING, 300) << "Unauthorized connection attempt: " << s.message().ToString();
+    KLOG_EVERY_N_SECS(WARNING, 300) << "Unauthorized connection attempt [EVERY 300 seconds]: " << s.message().ToString();
   }
   conn->CompleteNegotiation(std::move(s), std::move(rpc_error));
 }

--- a/src/kudu/rpc/server_negotiation.cc
+++ b/src/kudu/rpc/server_negotiation.cc
@@ -456,7 +456,7 @@ Status ServerNegotiation::HandleNegotiate(const NegotiatePB& request) {
           Sockaddr addr;
           RETURN_NOT_OK(socket_->GetPeerAddress(&addr));
           KLOG_EVERY_N_SECS(WARNING, 60)
-              << "client supports unknown authentication type, consider updating server, address: "
+              << "client supports unknown authentication type, consider updating server, address [EVERY 60 seconds]: "
               << addr.ToString();
           break;
         }


### PR DESCRIPTION
Summary: When we see messages in log file, it is important
to know that this message is sampled, because it helps us understand
why all peers are not logged or all situations are not logged.

Test Plan: Compiled kuduraft and test in prod

Reviewers:bhatvinay, yashtc, yichenshen

Subscribers:

Tasks:

Tags: