### PR TITLE
[FR] [perf] [1/n] perf optimization in watermark calulation

### DIFF
--- a/src/kudu/consensus/consensus_queue.h
+++ b/src/kudu/consensus/consensus_queue.h
@@ -596,25 +596,17 @@ class PeerMessageQueue {
   // given a pointer to it, the voter distribution and the watermarks
   // classified by region.
   // This function returns the old watermark.
-  int64_t ComputeNewWatermarkStaticMode(
-    int64_t* watermark,
+  int64_t DoComputeNewWatermarkStaticMode(
     const std::map<std::string, int>& voter_distribution,
-    const std::map<std::string, std::vector<int64_t> >& watermarks_by_region);
+    const std::map<std::string, std::vector<int64_t> >& watermarks_by_region,
+    int64_t* watermark);
+  int64_t ComputeNewWatermarkStaticMode(int64_t* watermark);
 
   // Function to compute the new `watermark` in the single region dynamic
   // mode given a pointer to it, the voter distribution and the watermarks
   // classified by region.
   // This function returns the old watermark.
-  int64_t ComputeNewWatermarkDynamicMode(
-    int64_t* watermark,
-    const std::map<std::string, int>& voter_distribution,
-    const std::map<std::string, std::vector<int64_t> >& watermarks_by_region);
-
-  // Function to compute the new `watermark` given a pointer to it and the
-  // watermarks classified by region. This function returns the old watermark.
-  int64_t ComputeNewWatermark(
-    int64_t* watermark,
-    const std::map<std::string, std::vector<int64_t> >& watermarks_by_region);
+  int64_t ComputeNewWatermarkDynamicMode(int64_t* watermark);
 
   // Function to compute the commit index in FlexiRaft. Same as
   // `AdvanceQueueWatermark` except that its only used for commit index
@@ -623,8 +615,7 @@ class PeerMessageQueue {
   // RaftConsensus instance while this function gets called.
   void AdvanceMajorityReplicatedWatermarkFlexiRaft(
       int64_t* watermark, const OpId& replicated_before,
-      const OpId& replicated_after,
-      ReplicaTypes replica_types, const TrackedPeer* who_caused);
+      const OpId& replicated_after, const TrackedPeer* who_caused);
 
   // Fetches the data commit quorum as a mapping from region to count of
   // votes required.

--- a/src/kudu/consensus/quorum_util.cc
+++ b/src/kudu/consensus/quorum_util.cc
@@ -910,5 +910,10 @@ void AdjustVoterDistributionWithCurrentVoters(
   }
 }
 
+bool IsStaticQuorumMode(QuorumMode mode) {
+  return (mode == QuorumMode::STATIC_DISJUNCTION ||
+    mode == QuorumMode::STATIC_CONJUNCTION);
+}
+
 }  // namespace consensus
 }  // namespace kudu

--- a/src/kudu/consensus/quorum_util.h
+++ b/src/kudu/consensus/quorum_util.h
@@ -156,6 +156,9 @@ void AdjustVoterDistributionWithCurrentVoters(
     const RaftConfigPB& config,
     std::map<std::string, int> *voter_distribution);
 
+// Is this mode a static quorum mode type?
+bool IsStaticQuorumMode(QuorumMode mode);
+
 }  // namespace consensus
 }  // namespace kudu
 


### PR DESCRIPTION
Summary:
AdvanceMajorityReplicatedWatermarkFlexiRaft() is a function that advances
queue watermarks in FlexiRaft. It does a bunch of expensive operations like:
(1) Compute a map of vectors (keyed by region name) with regional watermarks
(i.e a list of indexes for all peers indicating the last OpId that was acked by
that peer)
(2) Sort each of the vector in this map
(3) Build a voter_distribution map - i.e a map of number of voters in each
region (keyed by region name)
(4) Build another map with number of voters in each region based on
active_config
(5) Fix up the actual voters by iterating over maps from (3) and (4)

The key observation here is that in SINGLE_REGION_DYNAMIC mode, only the leader
region's voters can advance the commit index (i.e watermark). Hence, building
such maps is wasteful as it will be discarded immediately.

Fixes introduced in this diff:
(a) In SINGLE_REGION_DYNAMIC mode, instead of computing a map of vectors for
each region, a single vector containing last OpId for peers in leader region
is computed. This avoids map construction/destruction cost as well as additional
vector construction/destruction cost
(b) We need to sort only one vector instead of multiple vectors due to (1)
(c) No need to build another map with number of voters in each region. Just a
single integer with number of voters in leader region is computed. This also
eliminates the iteration and lookups in (5) mentioned above.
(d) Skip computing watermarks completely if the response being processed is
from a region other than leader region

Some part of the code had to be duplicated for efficiency and simplicity

We could also think of caching the voter_distribution map (and update it only
when a config change happens). Will explore this in a different PR.

Test Plan:
Existing tests for functional coverage.
Pending perf runs. Will update once I run those

Data showing commit latency of single row inserts is shown below. This is the client side latency (in seconds, measured by mysqlslap) to commit 5000 trxs (each trx is a single low insert into a simple table with two integer columns). Raft clearly shows better latency after the changes in this PR and PR 91)

Concurrency | Semi-sync Latency | Raft
======================================
1                     | 1.987                         | 2.086
2                     | 1.024                         | 1.166
4                    | 0.773                         | 0.735
8                    | 0.569                         | 0.47
16                  | 0.472                         | 0.331
32                  | 0.427                         | 0.253
64                  | 0.397                         | 0.204
128                | 0.372                         | 0.186
256                | 0.386                         | 0.19



Reviewers:

Subscribers:

Tasks:

Tags: