### PR TITLE
[kuduraft] [perf] [2/n] async count of local vote

### DIFF
--- a/src/kudu/consensus/consensus_queue.h
+++ b/src/kudu/consensus/consensus_queue.h
@@ -571,6 +571,11 @@ class PeerMessageQueue {
   // does not hold. If the queue is in NON_LEADER mode, does nothing.
   void CheckPeersInActiveConfigIfLeaderUnlocked() const;
 
+  // Generates a fake response to count the local peer's (leader's) vote after
+  // appending to the log. The fake response is scheduled to run aynchronously
+  // so that it does not block on queue_lock_
+  void DoLocalPeerAppendFinished(const OpId& id);
+
   // Callback when a REPLICATE message has finished appending to the local log.
   void LocalPeerAppendFinished(const OpId& id,
                                const StatusCallback& callback,


### PR DESCRIPTION
Summary:
In upstream kudu, appending to leader's log is an async operation. However, this
is turned into a synchronous operation in kuduraft fork. This means that the
threads that are appending to the log (flush phase of ordered-commit) are
blocked until the append is finished AND local response/votes are calculated.
This in turn blocks the ordered commit pipeline with no threads being able to
enter the ordered-commit until the last one finished "flushing". There are two
problems with this:
(1) Processing response (local or remote) is an expensive operation as identified by perf
profile
(2) PeerMessageQueue::queue_lock_ is a contended lock - contention between
threads that are wrtiting to local binlog, threads that are sending requests to
other peers, threads that are processing response from other peers.

(1) and (2) essentially blocks up the commit pipeline and increases commit
latency

While appending to local log is better done synchronously, processing the local
response need not be synchronous (with the log append). This diff tries to
refactor the code so that processing (fake) response from local peer and
counting local vote can be done asynchronously. This ensures that the log
append thread will not block on PeerMessageQueue::queue_lock_ and pile up all
threads that trying to enter ordered-commit

Test Plan:
Existing functional tests run fine.

Data showing commit latency of single row inserts is shown below. This is the client side latency (in seconds, measured by mysqlslap) to commit 5000 trxs (each trx is a single low insert into a simple table with two integer columns). Raft clearly shows better latency after the changes in PR90  and PR 91)

Concurrency | Semi-sync                | Raft
1                     | 1.987                         | 2.086
2                     | 1.024                         | 1.166
4                    | 0.773                         | 0.735
8                    | 0.569                         | 0.47
16                  | 0.472                         | 0.331
32                  | 0.427                         | 0.253
64                  | 0.397                         | 0.204
128                | 0.372                         | 0.186
256                | 0.386                         | 0.19

Reviewers:

Subscribers:

Tasks:

Tags: