### PR TITLE
Pipe in more metadata through an election

### DIFF
--- a/src/kudu/consensus/consensus.proto
+++ b/src/kudu/consensus/consensus.proto
@@ -542,6 +542,14 @@ message RunLeaderElectionRequestPB {
 
   // the id of the tablet
   required bytes tablet_id = 1;
+
+  // Time when the original server was promoted away from. We can use this to
+  // measure the total time of a chain of promotions
+  optional fixed64 original_start_time = 3;
+
+  // UUID of original server that was promoted away from, used when current
+  // server cannot be leader
+  optional bytes original_uuid = 4;
 }
 
 message RunLeaderElectionResponsePB {

--- a/src/kudu/consensus/raft_consensus_quorum-test.cc
+++ b/src/kudu/consensus/raft_consensus_quorum-test.cc
@@ -915,8 +915,8 @@ TEST_F(RaftConsensusQuorumTest, TestLeaderElectionWithQuiescedQuorum) {
     int64_t flush_count_before =
         new_leader->consensus_metadata_for_tests()->flush_count_for_tests();
     LOG(INFO) << "Running election for future leader with index " << (current_config_size - 1);
-    ASSERT_OK(new_leader->StartElection(RaftConsensus::ELECT_EVEN_IF_LEADER_IS_ALIVE,
-                                        RaftConsensus::EXTERNAL_REQUEST));
+    ASSERT_OK(new_leader->StartElection(ElectionMode::ELECT_EVEN_IF_LEADER_IS_ALIVE,
+                                        { ElectionReason::EXTERNAL_REQUEST }));
     WaitUntilLeaderForTests(new_leader.get());
     LOG(INFO) << "Election won";
     int64_t flush_count_after =

--- a/src/kudu/tserver/tablet_server_options.h
+++ b/src/kudu/tserver/tablet_server_options.h
@@ -32,6 +32,7 @@ namespace consensus {
 class ConsensusRoundHandler;
 class OpId;
 struct ElectionResult;
+struct ElectionContext;
 }
 
 namespace KC = kudu::consensus;
@@ -60,7 +61,8 @@ struct TabletServerOptions : public kudu::server::ServerBaseOptions {
   kudu::consensus::ConsensusRoundHandler *round_handler = nullptr;
 
   // Election Decision Callback
-  std::function<void(const consensus::ElectionResult&)> edcb;
+  std::function<void(const consensus::ElectionResult&,
+      const consensus::ElectionContext&)> edcb;
 
   // Term Advancement Callback
   std::function<void(int64_t)> tacb;


### PR DESCRIPTION
Summary:

ElectionContext is a struct that contains more metadata. We can use it
to:

1) Track election duration for a dead leader
2) Carry forward the original primary if we have multiple elections

Test Plan:

Loaded into fbcode and checked that tests are passing.

Reviewers: arahut, vinaybhat, yashb

Subscribers:

Tasks:

Tags:
Signed-off-by: Yichen <yichenshen@fb.com>