### PR TITLE
The callbacks need information about current leader to not have to reach

### DIFF
--- a/src/kudu/consensus/consensus_meta.cc
+++ b/src/kudu/consensus/consensus_meta.cc
@@ -275,6 +275,19 @@ std::pair<string, unsigned int> ConsensusMetadata::leader_hostport() const {
   return {};
 }
 
+Status ConsensusMetadata::GetConfigMemberCopy(
+    const std::string& uuid,
+    RaftPeerPB *member) {
+  DFAKE_SCOPED_RECURSIVE_LOCK(fake_lock_);
+  for (const RaftPeerPB& peer : ActiveConfig().peers()) {
+    if (peer.permanent_uuid() == uuid) {
+      *member = peer;
+      return Status::OK();
+    }
+  }
+  return Status::NotFound(Substitute("Peer with uuid $0 not found in consensus config", uuid));
+}
+
 RaftPeerPB::Role ConsensusMetadata::active_role() const {
   DFAKE_SCOPED_RECURSIVE_LOCK(fake_lock_);
   return active_role_;

--- a/src/kudu/consensus/consensus_meta.h
+++ b/src/kudu/consensus/consensus_meta.h
@@ -142,6 +142,8 @@ class ConsensusMetadata : public RefCountedThreadSafe<ConsensusMetadata> {
   // Returns the currently active role of the current node.
   RaftPeerPB::Role active_role() const;
 
+  Status GetConfigMemberCopy(const std::string& uuid, RaftPeerPB *member);
+
   // Copy the stored state into a ConsensusStatePB object.
   // To get the active configuration, specify 'type' = ACTIVE.
   // Otherwise, 'type' = COMMITTED will return a version of the

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -186,8 +186,8 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   typedef std::function<void(const ElectionResult&, const ElectionContext&)>
     ElectionDecisionCallback;
   typedef std::function<void(int64_t)> TermAdvancementCallback;
-  typedef std::function<void(const OpId opId)> NoOpReceivedCallback;
-  typedef std::function<void(int64_t)> LeaderDetectedCallback;
+  typedef std::function<void(const OpId opId, const RaftPeerPB&)> NoOpReceivedCallback;
+  typedef std::function<void(int64_t, const RaftPeerPB&)> LeaderDetectedCallback;
 
   ~RaftConsensus();
 
@@ -940,10 +940,10 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   void DoTermAdvancmentCallback(int64_t term);
 
   void ScheduleNoOpReceivedCallback(const ReplicateRefPtr& msg);
-  void DoNoOpReceivedCallback(const OpId opid);
+  void DoNoOpReceivedCallback(const OpId opid, const RaftPeerPB& leader_details);
 
   void ScheduleLeaderDetectedCallback(int64_t term);
-  void DoLeaderDetectedCallback(int64_t term);
+  void DoLeaderDetectedCallback(int64_t term, const RaftPeerPB& leader_details);
 
   // Checks if the term change is legal. If so, sets 'current_term'
   // to 'new_term' and sets 'has voted' to no for the current term.

--- a/src/kudu/tserver/tablet_server_options.h
+++ b/src/kudu/tserver/tablet_server_options.h
@@ -68,11 +68,11 @@ struct TabletServerOptions : public kudu::server::ServerBaseOptions {
   std::function<void(int64_t)> tacb;
 
   // No-OP received Callback
-  std::function<void(const consensus::OpId id)> norcb;
+  std::function<void(const consensus::OpId id, const kudu::consensus::RaftPeerPB&)> norcb;
 
   // Leader Detected Callback. This should eventually be reconciled
   // with NORCB.
-  std::function<void(int64_t)> ldcb;
+  std::function<void(int64_t, const kudu::consensus::RaftPeerPB&)> ldcb;
   bool disable_noop = false;
 
   // This is to enable a fresh instance join the ring with logs from


### PR DESCRIPTION
back into kuduraft

Summary: When a No-OP recieved or Leader detected callback is called,
we need to set information about the current leader for any reporting
or redirection for clients. This can need the implementation of the
callbacks to make a reverse call into kuduraft to get the
ConsensusState. However the ground could have shifted and thereby the
callback can either fail or act on wrong information. There are several
options to fix this. One is to check that ground has not shifted. The
other option which we implement here, is to make the callback have
enough information so as to not have to reach back into kuduraft. This
is based on what MySQL Raft needs today, but can evolve over time.

Test Plan: Since this is a callback, the real test is at the application
MySQL Raft level. Here we ensured that the compilation works which
ensures that the plumbing is correct.

Reviewers:

Subscribers:

Tasks:

Tags: