### PR TITLE
Enhancing authentication during negotiation to allow for external certs

### DIFF
--- a/src/kudu/rpc/server_negotiation.h
+++ b/src/kudu/rpc/server_negotiation.h
@@ -150,6 +150,11 @@ class ServerNegotiation {
   // server is properly set up.
   static Status PreflightCheckGSSAPI(const std::string& sasl_proto_name) WARN_UNUSED_RESULT;
 
+  enum class CertValidationCheck {
+    CERT_VALIDATION_USERID,
+    CERT_VALIDATION_COMMON_NAME
+  };
+
  private:
 
   // Parse a negotiate request from the client, deserializing it into 'msg'.
@@ -193,7 +198,7 @@ class ServerNegotiation {
 
   // Authenticate the client using the client's TLS certificate. Populates the
   // 'authenticated_user_' field with the certificate's subject.
-  Status AuthenticateByCertificate() WARN_UNUSED_RESULT;
+  Status AuthenticateByCertificate(CertValidationCheck mode) WARN_UNUSED_RESULT;
 
   // Handle case when client sends SASL_INITIATE request.
   // Returns Status::OK if the SASL negotiation is complete, or

--- a/src/kudu/security/cert.cc
+++ b/src/kudu/security/cert.cc
@@ -111,6 +111,18 @@ boost::optional<string> Cert::UserId() const {
   return string(buf, len);
 }
 
+boost::optional<string> Cert::CommonName() const {
+  SCOPED_OPENSSL_NO_PENDING_ERRORS;
+  X509_NAME* name = X509_get_subject_name(GetTopOfChainX509());
+  if (!name) {
+    return boost::none;
+  }
+  char buf[1024];
+  int len = X509_NAME_get_text_by_NID(name, NID_commonName, buf, arraysize(buf));
+  if (len < 0) return boost::none;
+  return string(buf, len);
+}
+
 vector<string> Cert::Hostnames() const {
   SCOPED_OPENSSL_NO_PENDING_ERRORS;
   vector<string> result;

--- a/src/kudu/security/cert.h
+++ b/src/kudu/security/cert.h
@@ -69,6 +69,9 @@ class Cert : public RawDataWrapper<STACK_OF(X509)> {
   // Return the 'userId' extension of the end-user cert, if set.
   boost::optional<std::string> UserId() const;
 
+  // Return the 'commonName' from the subjectName
+  boost::optional<std::string> CommonName() const;
+
   // Return the Kerberos principal encoded in the end-user certificate, if set.
   boost::optional<std::string> KuduKerberosPrincipal() const;
 

--- a/src/kudu/server/server_base.cc
+++ b/src/kudu/server/server_base.cc
@@ -176,6 +176,8 @@ DEFINE_string(rpc_tls_ciphers,
               "for more information.");
 TAG_FLAG(rpc_tls_ciphers, advanced);
 
+
+
 DEFINE_string(rpc_tls_min_protocol,
               kudu::security::SecurityDefaults::kDefaultTlsMinVersion,
               "The minimum protocol version to allow when for securing RPC "
@@ -183,30 +185,10 @@ DEFINE_string(rpc_tls_min_protocol,
               "'TLSv1.2'.");
 TAG_FLAG(rpc_tls_min_protocol, advanced);
 
-DEFINE_string(rpc_certificate_file, "",
-              "Path to a PEM encoded X509 certificate to use for securing RPC "
-              "connections with SSL/TLS. If set, '--rpc_private_key_file' and "
-              "'--rpc_ca_certificate_file' must be set as well.");
-DEFINE_string(rpc_private_key_file, "",
-              "Path to a PEM encoded private key paired with the certificate "
-              "from '--rpc_certificate_file'");
-DEFINE_string(rpc_ca_certificate_file, "",
-              "Path to the PEM encoded X509 certificate of the trusted external "
-              "certificate authority. The provided certificate should be the root "
-              "issuer of the certificate passed in '--rpc_certificate_file'.");
-DEFINE_string(rpc_private_key_password_cmd, "", "A Unix command whose output "
-              "returns the password used to decrypt the RPC server's private key "
-              "file specified in --rpc_private_key_file. If the .PEM key file is "
-              "not password-protected, this flag does not need to be set. "
-              "Trailing whitespace will be trimmed before it is used to decrypt "
-              "the private key.");
-
-// Setting TLS certs and keys via CLI flags is only necessary for external
-// PKI-based security, which is not yet production ready. Instead, see
-// internal PKI (ipki) and Kerberos-based authentication.
-TAG_FLAG(rpc_certificate_file, experimental);
-TAG_FLAG(rpc_private_key_file, experimental);
-TAG_FLAG(rpc_ca_certificate_file, experimental);
+DECLARE_string(rpc_certificate_file);
+DECLARE_string(rpc_private_key_file);
+DECLARE_string(rpc_ca_certificate_file);
+DECLARE_string(rpc_private_key_password_cmd);
 
 DEFINE_int32(rpc_default_keepalive_time_ms, 65000,
              "If an RPC connection from a client is idle for this amount of time, the server "


### PR DESCRIPTION
Summary: Kudu currently only allows internal CAs certificates to be used
for authentication. This patch removes the limitation through a gflag
and makes additional changes to fit the kuduraft TLS flow more in line
with what MysQL Raft needs.

1. Allows external cert to be used for auth if
rpc_allow_external_cert_authentication=true

2. Adds a GFLAG to provide a set of trusted CommonNames in the client
  certificate to be validated by Server.

3. Adds a GFLAG to switch AuthenticateByCertificate function from
   expecting userId and principal to expecting CN in Subject field.

4. Adds a function to TLS context which will enable the 3 files
   ca, cert and key files to be reprocessed/reloaded on expiry.

Test Plan: Tested it on mysql raft with rpms with rpc trace negotiation
turned on. Saw successful negotiation happen.

Reviewers:

Subscribers:

Tasks:

Tags: