### PR TITLE
Record the source UUID in Election Context

### DIFF
--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -543,6 +543,11 @@ Status RaftConsensus::StartElection(ElectionMode mode, ElectionContext context) 
     LockGuard l(lock_);
     RETURN_NOT_OK(CheckRunningUnlocked());
 
+    context.current_leader_uuid = GetLeaderUuidUnlocked();
+    if (context.source_uuid.empty()) {
+      context.source_uuid = context.current_leader_uuid;
+    }
+
     RaftPeerPB::Role active_role = cmeta_->active_role();
     if (active_role == RaftPeerPB::LEADER) {
       LOG_WITH_PREFIX_UNLOCKED(INFO) << Substitute(
@@ -2943,7 +2948,8 @@ void RaftConsensus::ElectionCallback(ElectionContext context, const ElectionResu
               LogPrefixThreadSafe() + "Unable to run election callback");
 }
 
-void RaftConsensus::DoElectionCallback(ElectionReason reason, const ElectionResult& result) {
+void RaftConsensus::DoElectionCallback(
+    const ElectionContext& context, const ElectionResult& result) {
   const int64_t election_term = result.vote_request.candidate_term();
   const bool was_pre_election = result.vote_request.is_pre_election();
   const char* election_type = was_pre_election ? "pre-election" : "election";
@@ -3042,7 +3048,7 @@ void RaftConsensus::DoElectionCallback(ElectionReason reason, const ElectionResu
   if (was_pre_election) {
     // We just won the pre-election. So, we need to call a real election.
     lock.unlock();
-    WARN_NOT_OK(StartElection(NORMAL_ELECTION, { reason }),
+    WARN_NOT_OK(StartElection(NORMAL_ELECTION, context),
                 "Couldn't start leader election after successful pre-election");
   } else {
     // We won a real election. Convert role to LEADER.
@@ -3058,7 +3064,7 @@ void RaftConsensus::DoElectionCallback(ElectionReason reason, const ElectionResu
 
 void RaftConsensus::NestedElectionDecisionCallback(
     ElectionContext context, const ElectionResult& result) {
-  DoElectionCallback(context.reason, result);
+  DoElectionCallback(context, result);
   if (!result.vote_request.is_pre_election() && edcb_) {
     edcb_(result, std::move(context));
   }

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -161,7 +161,7 @@ struct ElectionContext {
     reason(reason),
     is_chained_election(true),
     chained_start_time(std::move(chained_start_time)),
-    chained_source_uuid(std::move(source_uuid)) {}
+    source_uuid(std::move(source_uuid)) {}
 
   const ElectionReason reason;
 
@@ -175,8 +175,12 @@ struct ElectionContext {
   // The time the first election in the  started
   const Timepoint chained_start_time;
 
-  // The UUID of the leader at the start of the chain
-  const std::string chained_source_uuid;
+  // The UUID of the leader at the start of the election or election chain
+  std::string source_uuid;
+
+  // The UUID of the leader at the start of the election. If election is not
+  // a chain, this should be equal to source_uuid
+  std::string current_leader_uuid;
 };
 
 class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
@@ -813,7 +817,7 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   // Callback for leader election driver. ElectionCallback is run on the
   // reactor thread, so it simply defers its work to DoElectionCallback.
   void ElectionCallback(ElectionContext context, const ElectionResult& result);
-  void DoElectionCallback(ElectionReason reason, const ElectionResult& result);
+  void DoElectionCallback(const ElectionContext& context, const ElectionResult& result);
   void NestedElectionDecisionCallback(
       ElectionContext context, const ElectionResult& result);
 


### PR DESCRIPTION
Summary:

We can then use this to check in EDCB where the election came from, and
if we need to, log it.

Also realised that we don't thread context properly through a
pre-election. Fix that as well

Test Plan:

Tested in fbcode.

Reviewers: anirbanr-fb, bhatvinay, yashtc

Subscribers:

Tasks:

Tags:
Signed-off-by: Yichen <yichenshen@fb.com>