### PR TITLE
Transfer context

### DIFF
--- a/src/kudu/consensus/consensus.proto
+++ b/src/kudu/consensus/consensus.proto
@@ -534,6 +534,21 @@ message GetNodeInstanceResponsePB {
   required NodeInstancePB node_instance = 1;
 }
 
+message LeaderElectionContextPB {
+  // Time when the original server was promoted away from. We can use this to
+  // measure the total time of a chain of promotions
+  // Should be specified as nanoseconds since epoch
+  required fixed64 original_start_time = 1;
+
+  // UUID of original server that was promoted away from, used when current
+  // server cannot be leader
+  required bytes original_uuid = 2;
+
+  // True if the original promotion was due to the original leader specified in
+  // original_uuid being dead/unreachable
+  required bool is_origin_dead_promotion = 3 [default = false];
+}
+
 // Message that makes the local peer run leader election to be elected leader.
 // Assumes that a tablet with 'tablet_id' exists.
 message RunLeaderElectionRequestPB {
@@ -543,13 +558,10 @@ message RunLeaderElectionRequestPB {
   // the id of the tablet
   required bytes tablet_id = 1;
 
-  // Time when the original server was promoted away from. We can use this to
-  // measure the total time of a chain of promotions
-  optional fixed64 original_start_time = 3;
+  // optional fixed64 original_start_time = 3;
+  // optional bytes original_uuid = 4;
 
-  // UUID of original server that was promoted away from, used when current
-  // server cannot be leader
-  optional bytes original_uuid = 4;
+  optional LeaderElectionContextPB election_context = 5;
 }
 
 message RunLeaderElectionResponsePB {

--- a/src/kudu/consensus/consensus_peers.cc
+++ b/src/kudu/consensus/consensus_peers.cc
@@ -321,8 +321,7 @@ void Peer::SendNextRequest(bool even_if_queue_empty) {
                               });
 }
 
-Status Peer::StartElection() {
-  RunLeaderElectionRequestPB req;
+Status Peer::StartElection(RunLeaderElectionRequestPB req) {
   RunLeaderElectionResponsePB resp;
   RpcController controller;
   req.set_dest_uuid(peer_pb().permanent_uuid());

--- a/src/kudu/consensus/consensus_peers.h
+++ b/src/kudu/consensus/consensus_peers.h
@@ -89,7 +89,7 @@ class Peer : public std::enable_shared_from_this<Peer> {
   // StartElection request.
   // The StartElection RPC does not count as the single outstanding request
   // that this class tracks.
-  Status StartElection();
+  Status StartElection(RunLeaderElectionRequestPB req = {});
 
   const RaftPeerPB& peer_pb() const { return peer_pb_; }
 

--- a/src/kudu/consensus/peer_manager.cc
+++ b/src/kudu/consensus/peer_manager.cc
@@ -108,7 +108,8 @@ void PeerManager::SignalRequest(bool force_if_queue_empty) {
   }
 }
 
-Status PeerManager::StartElection(const std::string& uuid) {
+Status PeerManager::StartElection(
+    const std::string& uuid, RunLeaderElectionRequestPB req) {
   std::shared_ptr<Peer> peer;
   {
     std::lock_guard<simple_spinlock> lock(lock_);
@@ -117,7 +118,7 @@ Status PeerManager::StartElection(const std::string& uuid) {
   if (!peer) {
     return Status::NotFound("unknown peer");
   }
-  return peer->StartElection();
+  return peer->StartElection(std::move(req));
 }
 
 void PeerManager::Close() {

--- a/src/kudu/consensus/peer_manager.h
+++ b/src/kudu/consensus/peer_manager.h
@@ -62,7 +62,8 @@ class PeerManager {
   void SignalRequest(bool force_if_queue_empty = false);
 
   // Start an election on the peer with UUID 'uuid'.
-  Status StartElection(const std::string& uuid);
+  Status StartElection(const std::string& uuid,
+                       RunLeaderElectionRequestPB req = {});
 
   // Closes all peers.
   void Close();

--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -543,6 +543,11 @@ Status RaftConsensus::StartElection(ElectionMode mode, ElectionContext context) 
     LockGuard l(lock_);
     RETURN_NOT_OK(CheckRunningUnlocked());
 
+    context.current_leader_uuid = GetLeaderUuidUnlocked();
+    if (context.source_uuid.empty()) {
+      context.source_uuid = context.current_leader_uuid;
+    }
+
     RaftPeerPB::Role active_role = cmeta_->active_role();
     if (active_role == RaftPeerPB::LEADER) {
       LOG_WITH_PREFIX_UNLOCKED(INFO) << Substitute(
@@ -2943,7 +2948,8 @@ void RaftConsensus::ElectionCallback(ElectionContext context, const ElectionResu
               LogPrefixThreadSafe() + "Unable to run election callback");
 }
 
-void RaftConsensus::DoElectionCallback(ElectionReason reason, const ElectionResult& result) {
+void RaftConsensus::DoElectionCallback(
+    const ElectionContext& context, const ElectionResult& result) {
   const int64_t election_term = result.vote_request.candidate_term();
   const bool was_pre_election = result.vote_request.is_pre_election();
   const char* election_type = was_pre_election ? "pre-election" : "election";
@@ -3042,7 +3048,7 @@ void RaftConsensus::DoElectionCallback(ElectionReason reason, const ElectionResu
   if (was_pre_election) {
     // We just won the pre-election. So, we need to call a real election.
     lock.unlock();
-    WARN_NOT_OK(StartElection(NORMAL_ELECTION, { reason }),
+    WARN_NOT_OK(StartElection(NORMAL_ELECTION, context),
                 "Couldn't start leader election after successful pre-election");
   } else {
     // We won a real election. Convert role to LEADER.
@@ -3058,7 +3064,7 @@ void RaftConsensus::DoElectionCallback(ElectionReason reason, const ElectionResu
 
 void RaftConsensus::NestedElectionDecisionCallback(
     ElectionContext context, const ElectionResult& result) {
-  DoElectionCallback(context.reason, result);
+  DoElectionCallback(context, result);
   if (!result.vote_request.is_pre_election() && edcb_) {
     edcb_(result, std::move(context));
   }

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -161,7 +161,7 @@ struct ElectionContext {
     reason(reason),
     is_chained_election(true),
     chained_start_time(std::move(chained_start_time)),
-    chained_source_uuid(std::move(source_uuid)) {}
+    source_uuid(std::move(source_uuid)) {}
 
   const ElectionReason reason;
 
@@ -175,8 +175,12 @@ struct ElectionContext {
   // The time the first election in the  started
   const Timepoint chained_start_time;
 
-  // The UUID of the leader at the start of the chain
-  const std::string chained_source_uuid;
+  // The UUID of the leader at the start of the election or election chain
+  std::string source_uuid;
+
+  // The UUID of the leader at the start of the election. If election is not
+  // a chain, this should be equal to source_uuid
+  std::string current_leader_uuid;
 };
 
 class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
@@ -813,7 +817,7 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   // Callback for leader election driver. ElectionCallback is run on the
   // reactor thread, so it simply defers its work to DoElectionCallback.
   void ElectionCallback(ElectionContext context, const ElectionResult& result);
-  void DoElectionCallback(ElectionReason reason, const ElectionResult& result);
+  void DoElectionCallback(const ElectionContext& context, const ElectionResult& result);
   void NestedElectionDecisionCallback(
       ElectionContext context, const ElectionResult& result);
 

--- a/src/kudu/tserver/CMakeLists.txt
+++ b/src/kudu/tserver/CMakeLists.txt
@@ -77,6 +77,9 @@ add_custom_command(TARGET tserver
     COMMAND ar -t $<TARGET_FILE:kudu_common> >> touch_link
     COMMAND ar -t $<TARGET_FILE:kudu_fs> >> touch_link
     COMMAND ar -t $<TARGET_FILE:kudu_util_compression> >> touch_link
+    COMMAND ar -t $<TARGET_FILE:kudu_tools_util> >> touch_link
+    COMMAND ar -t $<TARGET_FILE:kudu_tool> >> touch_link
+    COMMAND ar -t $<TARGET_FILE:tool_proto> >> touch_link
     COMMAND ar -t $<TARGET_FILE:security> >> touch_link
     COMMAND ar -t $<TARGET_FILE:krpc> >> touch_link
     COMMAND ar -t $<TARGET_FILE:krb5_realm_override> >> touch_link
@@ -99,7 +102,7 @@ add_custom_command(TARGET tserver
     COMMAND ar -t $<TARGET_FILE:gutil> >> touch_link
     COMMAND cat touch_link | xargs ar -qcs ${C_LIB}
     COMMAND ranlib ${C_LIB}
-    DEPENDS tcmalloc profiler tserver kserver server_process consensus log kudu_fs kudu_common kudu_util clock kudu_util_compression kudu_common_proto maintenance_manager_proto util_compression_proto fs_proto log_proto consensus_metadata_proto consensus_proto histogram_proto rpc_header_proto rpc_introspection_proto token_proto pb_util_proto tserver_admin_proto server_base_proto
+    DEPENDS tcmalloc profiler tserver kserver server_process consensus log kudu_fs kudu_common kudu_util clock kudu_util_compression kudu_common_proto kudu_tools_util kudu_tool tool_proto maintenance_manager_proto util_compression_proto fs_proto log_proto consensus_metadata_proto consensus_proto histogram_proto rpc_header_proto rpc_introspection_proto token_proto pb_util_proto tserver_admin_proto server_base_proto
 )
 
 #########################################


### PR DESCRIPTION
Link up Election Context from TransferLeader to EDCB

    Summary:

    Previously we added more metdata for EDCB, but it was limited to a
    single election. This change pipes ElectionContext received from
    TransferLeader through kudu rpcs so that it eventually arrives at the
    new leader's EDCB.

    In MySQL Raft, when EDCB is called and it determines that we need
    another elections, the ElectionContext can be passed back to preserve
    context.

    Test Plan:

    Tested with fbcode.

    Reviewers: anirbanr-fb, bhatvinay, yashtc

    Subscribers:

    Tasks:

    Tags:
    Signed-off-by: Yichen <yichenshen@fb.com>