### PR TITLE
updating voter_distribution inside the committed config

### DIFF
--- a/src/kudu/consensus/consensus_meta.cc
+++ b/src/kudu/consensus/consensus_meta.cc
@@ -192,6 +192,22 @@ void ConsensusMetadata::set_committed_config(const RaftConfigPB& config) {
   }
 }
 
+void ConsensusMetadata::set_committed_config_raw(const RaftConfigPB &config) {
+  DFAKE_SCOPED_RECURSIVE_LOCK(fake_lock_);
+  *pb_.mutable_committed_config() = config;
+}
+
+kudu::Status ConsensusMetadata::voter_distribution(std::map<std::string, int32> *vd) const {
+  DFAKE_SCOPED_RECURSIVE_LOCK(fake_lock_);
+  if (!pb_.has_committed_config()) {
+    return kudu::Status::NotFound("Committed config not present to get voter distribution");
+  }
+  vd->insert(
+      pb_.committed_config().voter_distribution().begin(),
+      pb_.committed_config().voter_distribution().end());
+  return kudu::Status::OK();
+}
+
 bool ConsensusMetadata::has_pending_config() const {
   DFAKE_SCOPED_RECURSIVE_LOCK(fake_lock_);
   return has_pending_config_;

--- a/src/kudu/consensus/consensus_meta.h
+++ b/src/kudu/consensus/consensus_meta.h
@@ -108,6 +108,12 @@ class ConsensusMetadata : public RefCountedThreadSafe<ConsensusMetadata> {
   const RaftConfigPB& CommittedConfig() const;
   void set_committed_config(const RaftConfigPB& config);
 
+  // Same as above but dont update active role
+  void set_committed_config_raw(const RaftConfigPB &config);
+
+  // Getter for Voter Distribution map
+  Status voter_distribution(std::map<std::string, int32> *vd) const;
+
   // Returns whether a pending configuration is set.
   bool has_pending_config() const;
 

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -434,6 +434,12 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   // Change the proxy topology.
   Status ChangeProxyTopology(const ProxyTopologyPB& proxy_topology);
 
+  // On a live Raft Instance allow for changes to voter_distribution map
+  Status ChangeVoterDistribution(const TopologyConfigPB &topology_config);
+
+  // Get the voter distribution from the committed config
+  Status GetVoterDistribution(std::map<std::string, int32> *vd) const;
+
   // Return the proxy topology.
   ProxyTopologyPB GetProxyTopology() const;
 


### PR DESCRIPTION
Summary: The voter distribution is used by Flexi Raft to
get proper quorums to use for commit and quorum intersection.

Till now we had no mechanism to update the voter distribution.
With this patch we provide a direct update from outside to
update the voter distribution inside the committed config.

When new regions are to be added to the ring, first the new
voter distribution should be sent and updated before the voting
members are added. FlexiRaft has the protections to make sure
that the minimum quorum size rules will be enforced during leader
election.

Test Plan: This was tested on the MySQL raft side with a unittest.

Reviewers: yichenshen

Subscribers:

Tasks:

Tags: