### PR TITLE
Better introspection for rpc service queue

### DIFF
--- a/src/kudu/rpc/inbound_call.cc
+++ b/src/kudu/rpc/inbound_call.cc
@@ -237,17 +237,23 @@ Status InboundCall::AddOutboundSidecar(unique_ptr<RpcSidecar> car, int* idx) {
 
 string InboundCall::ToString() const {
   if (header_.has_request_id()) {
-    return Substitute("Call $0 from $1 (ReqId={client: $2, seq_no=$3, attempt_no=$4})",
+    return Substitute("Call $0 from $1 (ReqId={client: $2, seq_no=$3, attempt_no=$4}) recv: $5 handled: $6 comp: $7",
                       remote_method_.ToString(),
                       conn_->remote().ToString(),
                       header_.request_id().client_id(),
                       header_.request_id().seq_no(),
-                      header_.request_id().attempt_no());
+                      header_.request_id().attempt_no(),
+                      timing_.time_received.ToString(),
+                      (timing_.time_handled.Initialized() ? timing_.time_handled.ToString() : "NOT_HANDLED"),
+                      (timing_.time_completed.Initialized() ? timing_.time_completed.ToString() : "NOT_COMPLETED"));
   }
-  return Substitute("Call $0 from $1 (request call id $2)",
+  return Substitute("Call $0 from $1 (request call id $2) recv: $3 handled: $4 comp: $5",
                       remote_method_.ToString(),
                       conn_->remote().ToString(),
-                      header_.call_id());
+                      header_.call_id(),
+                      timing_.time_received.ToString(),
+                      (timing_.time_handled.Initialized() ? timing_.time_handled.ToString() : "NOT_HANDLED"),
+                      (timing_.time_completed.Initialized() ? timing_.time_completed.ToString() : "NOT_COMPLETED"));
 }
 
 void InboundCall::DumpPB(const DumpRunningRpcsRequestPB& req,

--- a/src/kudu/rpc/service_pool.h
+++ b/src/kudu/rpc/service_pool.h
@@ -18,6 +18,7 @@
 #ifndef KUDU_SERVICE_POOL_H
 #define KUDU_SERVICE_POOL_H
 
+#include <atomic>
 #include <cstddef>
 #include <functional>
 #include <string>
@@ -92,6 +93,11 @@ class ServicePool : public RpcService {
 
   const std::string service_name() const;
 
+  /**
+   * Dump the current contents of the service queue
+   */
+  std::string RpcServiceQueueToString() const;
+
  private:
   void RunThread();
   void RejectTooBusy(InboundCall* c);
@@ -107,6 +113,7 @@ class ServicePool : public RpcService {
   bool closing_;
 
   std::function<void(void)> too_busy_hook_;
+  std::atomic<bool> logged_busy_;
 
   DISALLOW_COPY_AND_ASSIGN(ServicePool);
 };

--- a/src/kudu/tserver/tablet_server.cc
+++ b/src/kudu/tserver/tablet_server.cc
@@ -27,12 +27,14 @@
 #ifdef FB_DO_NOT_REMOVE
 #include "kudu/cfile/block_cache.h"
 #endif
+#include "kudu/consensus/consensus.service.h"
 #include "kudu/fs/error_manager.h"
 #include "kudu/fs/fs_manager.h"
 #include "kudu/gutil/bind.h"
 #include "kudu/gutil/bind_helpers.h"
 #include "kudu/gutil/strings/substitute.h"
 #include "kudu/rpc/service_if.h"
+#include "kudu/rpc/service_pool.h"
 #ifdef FB_DO_NOT_REMOVE
 #include "kudu/tserver/heartbeater.h"
 #include "kudu/tserver/scanners.h"
@@ -155,21 +157,15 @@ Status TabletServer::Start() {
 
   gscoped_ptr<ServiceIf> ts_service(new TabletServiceImpl(this));
   gscoped_ptr<ServiceIf> admin_service(new TabletServiceAdminImpl(this));
-#endif
 
-#ifdef FB_DO_NOT_REMOVE
   gscoped_ptr<ServiceIf> tablet_copy_service(new TabletCopyServiceImpl(
       this, tablet_manager_.get()));
 
   RETURN_NOT_OK(RegisterService(std::move(ts_service)));
   RETURN_NOT_OK(RegisterService(std::move(admin_service)));
-#endif
 
-#ifdef FB_DO_NOT_REMOVE
   RETURN_NOT_OK(RegisterService(std::move(tablet_copy_service)));
-#endif
 
-#ifdef FB_DO_NOT_REMOVE
   RETURN_NOT_OK(heartbeater_->Start());
   RETURN_NOT_OK(maintenance_manager_->Start());
 #endif
@@ -206,6 +202,15 @@ void TabletServer::Shutdown() {
     LOG(INFO) << name << " shutdown complete.";
     initted_ = false;
   }
+}
+
+std::string TabletServer::ConsensusServiceRpcQueueToString() const {
+  const kudu::rpc::ServicePool* pool = rpc_server_->service_pool(
+     kudu::consensus::ConsensusServiceIf::static_service_name());
+  if (pool) {
+    return pool->RpcServiceQueueToString();
+  }
+  return "";
 }
 
 } // namespace tserver

--- a/src/kudu/tserver/tablet_server.h
+++ b/src/kudu/tserver/tablet_server.h
@@ -97,6 +97,11 @@ class TabletServer : public kserver::KuduServer {
 
 #endif
 
+  /*
+   * Capture a snapshot of the RPC service queue in the server log file.
+   */
+  std::string ConsensusServiceRpcQueueToString() const;
+
  private:
   friend class TabletServerTestBase;
   friend class TSTabletManager;


### PR DESCRIPTION
Summary:
1. We need to be able to introspect rpc service queues.
The VLOG output on service_pool will now trigger each time there is
service full situation.

2. One more change done here is to make it a knob to manage peer health.
At the end of RequestForPeer, we take the consensus queue lock again
to manage peer health. However all of that is being ignored today in
mysql raft as automatic eviction of peers is undesirable. So for high
throughput of write rates, making it optional to do this extra
management.

3. Also incremented failed_attempts each time there is a RequestForPeer
failure in SendNextRequest

Test Plan: Tested on mysql raft plugin side with direct calls to
service introspection report.

Reviewers:

Subscribers:

Tasks:

Tags: