### PR TITLE
[kuduraft] change ReadReplicatesInRange() to send additional context

### DIFF
--- a/src/kudu/consensus/consensus_queue.h
+++ b/src/kudu/consensus/consensus_queue.h
@@ -269,6 +269,14 @@ class PeerMessageQueue {
   // Return the next OpId to be appended to the queue in the current term.
   OpId GetNextOpId() const;
 
+  // Get the TrackedPeer corresponding to uuid. The tracked-peer is returned in
+  // 'peer'
+  //
+  // Returns Status::OK() if peer exists.
+  // Returns Status::NotFound() if peer does not exist (and peer is set to
+  // nullptr)
+  Status FindPeer(const std::string& uuid, TrackedPeer* peer);
+
   // Assembles a request for a peer, adding entries past 'op_id' up to
   // 'consensus_max_batch_size_bytes'.
   // Returns OK if the request was assembled, or Status::NotFound() if the

--- a/src/kudu/consensus/log-test.cc
+++ b/src/kudu/consensus/log-test.cc
@@ -586,7 +586,7 @@ TEST_P(LogTestOptionalCompression, TestGCWithLogRunning) {
     vector<ReplicateMsg*> repls;
     ElementDeleter d(&repls);
     Status s = log_->reader()->ReadReplicatesInRange(
-      1, 2, LogReader::kNoSizeLimit, /*for_peer_uuid=*/boost::none, &repls);
+      1, 2, LogReader::kNoSizeLimit, ReadContext(), &repls);
     ASSERT_TRUE(s.IsNotFound()) << s.ToString();
   }
 
@@ -980,7 +980,7 @@ TEST_P(LogTestOptionalCompression, TestReadLogWithReplacedReplicates) {
                     start_index,
                     end_index,
                     LogReader::kNoSizeLimit,
-                    /*for_peer_uuid=*/boost::none,
+                    ReadContext(),
                     &repls));
         ASSERT_EQ(end_index - start_index + 1, repls.size());
         int expected_index = start_index;
@@ -1009,7 +1009,7 @@ TEST_P(LogTestOptionalCompression, TestReadLogWithReplacedReplicates) {
               start_index,
               end_index,
               size_limit,
-              /*for_peer_uuid=*/boost::none,
+              ReadContext(),
               &repls));
         ASSERT_LE(repls.size(), end_index - start_index + 1);
         int total_size = 0;
@@ -1057,7 +1057,7 @@ TEST_P(LogTestOptionalCompression, TestReadReplicatesHighIndex) {
         first_log_index,
         first_log_index + kSequenceLength - 1,
         LogReader::kNoSizeLimit,
-        /*for_peer_uuid=*/boost::none,
+        ReadContext(),
         &replicates));
   ASSERT_EQ(kSequenceLength, replicates.size());
   ASSERT_GT(op_id.index(), std::numeric_limits<int32_t>::max());

--- a/src/kudu/consensus/log.cc
+++ b/src/kudu/consensus/log.cc
@@ -1008,7 +1008,7 @@ Status Log::ReadReplicatesInRange(
     int64_t starting_at,
     int64_t up_to,
     int64_t max_bytes_to_read,
-    const boost::optional<std::string>& /* for_peer_uuid */,
+    const consensus::ReadContext& /* context */,
     std::vector<consensus::ReplicateMsg*>* replicates) const {
   return reader()->ReadReplicatesInRange(
       starting_at, up_to, max_bytes_to_read, replicates);

--- a/src/kudu/consensus/log.h
+++ b/src/kudu/consensus/log.h
@@ -93,6 +93,16 @@ struct ConsensusBootstrapInfo {
  private:
   DISALLOW_COPY_AND_ASSIGN(ConsensusBootstrapInfo);
 };
+
+struct ReadContext {
+  ReadContext() {};
+  ~ReadContext() {};
+
+  const std::string* for_peer_uuid = nullptr;
+  const std::string* for_peer_host = nullptr;
+  uint32_t for_peer_port = 0;
+};
+
 }
 
 namespace log {
@@ -303,7 +313,7 @@ class Log : public RefCountedThreadSafe<Log> {
       int64_t starting_at,
       int64_t up_to,
       int64_t max_bytes_to_read,
-      const boost::optional<std::string>& for_peer_uuid,
+      const consensus::ReadContext& context,
       std::vector<consensus::ReplicateMsg*>* replicates) const;
   virtual Status LookupOpId(int64_t op_index, consensus::OpId* op_id) const;
 

--- a/src/kudu/consensus/log_cache.cc
+++ b/src/kudu/consensus/log_cache.cc
@@ -546,7 +546,7 @@ int64_t TotalByteSizeForMessage(const ReplicateMsg& msg) {
 
 Status LogCache::ReadOps(int64_t after_op_index,
                          int max_size_bytes,
-                         const boost::optional<std::string>& for_peer_uuid,
+                         const ReadContext& context,
                          std::vector<ReplicateRefPtr>* messages,
                          OpId* preceding_op) {
   DCHECK_GE(after_op_index, 0);
@@ -561,7 +561,7 @@ Status LogCache::ReadOps(int64_t after_op_index,
       // chance to update the error manager and report the error to upper layer
       vector<ReplicateMsg*> raw_replicate_ptrs;
       log_->ReadReplicatesInRange(
-          after_op_index, after_op_index + 1, max_size_bytes, for_peer_uuid,
+          after_op_index, after_op_index + 1, max_size_bytes, context,
           &raw_replicate_ptrs);
       for (ReplicateMsg* msg : raw_replicate_ptrs) {
         delete msg;
@@ -596,7 +596,7 @@ Status LogCache::ReadOps(int64_t after_op_index,
       vector<ReplicateMsg*> raw_replicate_ptrs;
       RETURN_NOT_OK_PREPEND(
         log_->ReadReplicatesInRange(
-          next_index, up_to, remaining_space, for_peer_uuid, &raw_replicate_ptrs),
+          next_index, up_to, remaining_space, context, &raw_replicate_ptrs),
         Substitute("Failed to read ops $0..$1", next_index, up_to));
       l.lock();
       VLOG_WITH_PREFIX_UNLOCKED(2)

--- a/src/kudu/consensus/log_cache.h
+++ b/src/kudu/consensus/log_cache.h
@@ -49,6 +49,7 @@ namespace consensus {
 
 class OpId;
 class ReplicateMsg;
+struct ReadContext;
 
 // Write-through cache for the log.
 //
@@ -88,7 +89,7 @@ class LogCache {
   // of time and should not be called with important locks held, etc.
   Status ReadOps(int64_t after_op_index,
                  int max_size_bytes,
-                 const boost::optional<std::string>& for_peer_uuid,
+                 const ReadContext& context,
                  std::vector<ReplicateRefPtr>* messages,
                  OpId* preceding_op);
 


### PR DESCRIPTION
Summary:
The said API is changed to send additional information. For now,
additional information sent is the host and port of the peer for which
the request is being built. This enables upper layers to make use of
these information without having to call back into kuduraft for fetching
information again (which leads to deadlocks in certain conditions)

Test Plan:
Built local tp2 checkouts and ensured that proper information is passed

Reviewers: arahut

Subscribers:

Tasks:

Tags: