### PR TITLE
[kuduraft] [compression] ability to compress messages read from the log

### DIFF
--- a/src/kudu/consensus/consensus_queue.cc
+++ b/src/kudu/consensus/consensus_queue.cc
@@ -728,6 +728,7 @@ Status PeerMessageQueue::RequestForPeer(const string& uuid,
     read_context.for_peer_uuid = &uuid;
     read_context.for_peer_host = &peer_copy.peer_pb.last_known_addr().host();
     read_context.for_peer_port = peer_copy.peer_pb.last_known_addr().port();
+    read_context.route_via_proxy = route_via_proxy;
 
     // We try to get the follower's next_index from our log.
     Status s = log_cache_.ReadOps(peer_copy.next_index - 1,

--- a/src/kudu/consensus/log.h
+++ b/src/kudu/consensus/log.h
@@ -101,6 +101,7 @@ struct ReadContext {
   const std::string* for_peer_uuid = nullptr;
   const std::string* for_peer_host = nullptr;
   uint32_t for_peer_port = 0;
+  bool route_via_proxy = false;
 };
 
 }

--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -4048,6 +4048,11 @@ Status RaftConsensus::SetCompressionCodec(const std::string& codec) {
   return queue_->log_cache()->SetCompressionCodec(codec);
 }
 
+Status RaftConsensus::EnableCompressionOnCacheMiss(bool enable) {
+  LockGuard l(lock_);
+  return queue_->log_cache()->EnableCompressionOnCacheMiss(enable);
+}
+
 ////////////////////////////////////////////////////////////////////////
 // ConsensusBootstrapInfo
 ////////////////////////////////////////////////////////////////////////

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -588,6 +588,9 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   // Set the compression codec to be used to compress ReplicateMsg payload
   Status SetCompressionCodec(const std::string& codec);
 
+  // Enables (or disables) compression of messages read from log
+  Status EnableCompressionOnCacheMiss(bool enable);
+
  protected:
   RaftConsensus(ConsensusOptions options,
                 RaftPeerPB local_peer_pb,


### PR DESCRIPTION
Summary:
Adds the ability to compress messages that are read from the log.
(1) Requests meant for proxy host is not compressed. This is because the
pyload is ignored for a proxy request and compression is wasteful
(2) A new flag in log-cache controls the feature so that it can be
enabled/disabled. This makes rollout and testing easier.
(3) Compression is done outside of LogCache::lock_ to avoid contending
with writes.

Test Plan:
Integration tests added in plugin and mtr in mysql

Reviewers: arahut

Subscribers:

Tasks:

Tags: