### PR TITLE
[kuduraft] lower verbosity of some log messages

### DIFF
--- a/src/kudu/consensus/log_index.cc
+++ b/src/kudu/consensus/log_index.cc
@@ -478,7 +478,7 @@ void LogIndex::GC(int64_t min_index_to_retain) {
       PLOG(WARNING) << "Unable to delete index chunk " << path;
       continue;
     }
-    LOG(INFO) << "Deleted log index segment " << path;
+    VLOG(2) << "Deleted log index segment " << path;
     {
       std::lock_guard<simple_spinlock> l(open_chunks_lock_);
       open_chunks_.erase(chunk_idx);

--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -1756,7 +1756,12 @@ Status RaftConsensus::UpdateReplica(const ConsensusRequestPB* request,
                                 request->caller_uuid(),
                                 request->caller_term(),
                                 prepare_status.ToString());
-        LOG_WITH_PREFIX_UNLOCKED(INFO) << msg;
+
+        // Log the message only when there is no rotation message in this batch
+        if (!expected_rotation_delay) {
+          LOG_WITH_PREFIX_UNLOCKED(INFO) << msg;
+        }
+
         FillConsensusResponseError(response, ConsensusErrorPB::CANNOT_PREPARE,
                                    Status::IllegalState(msg));
         FillConsensusResponseOKUnlocked(response);


### PR DESCRIPTION
Summary:
High rate rates can cause these log messages to flood. Reducing
verbosity (since we have the ability to increase it dynamically)

Test Plan: CI

Reviewers: arahut

Subscribers:

Tasks:

Tags: