### PR TITLE
[kuduraft] Propagate candidate peer information

### DIFF
--- a/src/kudu/consensus/consensus.proto
+++ b/src/kudu/consensus/consensus.proto
@@ -351,6 +351,14 @@ message ConsensusStatusPB {
   optional ConsensusErrorPB error = 3;
 }
 
+// The candidate populates this field and sends it along with the RequestVote
+// RPC.Current usage is mainly for logging to improve debugging leader
+// elections
+message CandidateContext {
+  // Candidate peer information
+  optional RaftPeerPB candidate_peer_pb = 1;
+}
+
 // A request from a candidate peer that wishes to become leader of
 // the configuration serving tablet with 'tablet_id'.
 // See RAFT sec. 5.2.
@@ -388,6 +396,9 @@ message VoteRequestPB {
   // In a "pre-election", voters should respond how they _would_ have voted
   // but not actually record the vote.
   optional bool is_pre_election = 7 [ default = false ];
+
+  // Additional candidate context that is passed by the candidate
+  optional CandidateContext candidate_context = 8;
 }
 
 // A response from a replica to a leader election request.

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -844,6 +844,9 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
                                        const std::string& hostname_port,
                                        VoteResponsePB* response);
 
+  // Get the context sent by the candidate as a string. Used for logging
+  std::string GetCandidateContextString(const VoteRequestPB* request);
+
   // Callback for leader election driver. ElectionCallback is run on the
   // reactor thread, so it simply defers its work to DoElectionCallback.
   void ElectionCallback(ElectionContext context, const ElectionResult& result);


### PR DESCRIPTION
Summary:
When an election is started, the candidate populates its own peer_pb
into the new context that gets passed through RequestVote() rpc. This
enables better logging on other ring menebers. For now, the other peers
only log the host-port. Note that if the candidate is already in the active
config tracked by a peer, then the peer (responding to RequestVote())
already has the host-port. This change is more useful when the candidate
is not in the active config - makes debugging easier.

In future the same context can be used to exchange other information
like sql lag, system stats to make a more informed decision in election.

In a subsequent diff, I will make the change where the candidate does an
exponential backoff (after losing an election) before starting a new
one. This needs more thought since the protocol says that a peer should
respond 'yes' to a candidate who is not in its own active config, but is
caught up and has the latest log (basic necessity of config change
protocol).

Test Plan: build plugin adn run tests

Reviewers: arahut

Subscribers:

Tasks:

Tags: