### PR TITLE
[kuduraft] aggressive backoffs in leader elections from a candidate not in config

### DIFF
--- a/src/kudu/consensus/consensus.proto
+++ b/src/kudu/consensus/consensus.proto
@@ -401,6 +401,15 @@ message VoteRequestPB {
   optional CandidateContext candidate_context = 8;
 }
 
+// Additional context that a voter sends back in the response to RequestVote()
+// rpc
+message VoterContext {
+  // Candidate was removed from the voter's committed config and is currently
+  // tracked in the voter's 'removed_peers_' list. This is used by the candidate
+  // to perform aggressive backoffs
+  optional bool is_candidate_removed = 1 [ default = false ];
+}
+
 // A response from a replica to a leader election request.
 message VoteResponsePB {
   // The uuid of the node sending the reply.
@@ -421,6 +430,9 @@ message VoteResponsePB {
 
   // Last known leader as per the responding voter.
   optional LastKnownLeaderPB last_known_leader = 6;
+
+  // Additional context sent back by the voter
+  optional VoterContext voter_context = 7;
 
   // TODO: Migrate ConsensusService to the AppStatusPB RPC style and merge these errors.
   // Error message from the consensus implementation.

--- a/src/kudu/consensus/quorum_util.h
+++ b/src/kudu/consensus/quorum_util.h
@@ -118,11 +118,15 @@ Status VerifyConsensusState(const ConsensusStatePB& cstate);
 // Provide a textual description of the difference between two consensus states,
 // suitable for logging.
 std::string DiffConsensusStates(const ConsensusStatePB& old_state,
-                                const ConsensusStatePB& new_state);
+                                const ConsensusStatePB& new_state,
+                                std::vector<std::string>* evicted_peers = nullptr);
 
 // Same as the above, but just the RaftConfigPB portion of the configuration.
+// If some peers are evicted in the new_config, then returns the evicted peer
+// uuids in 'evicted_peers'
 std::string DiffRaftConfigs(const RaftConfigPB& old_config,
-                            const RaftConfigPB& new_config);
+                            const RaftConfigPB& new_config,
+                            std::vector<std::string>* evicted_peers = nullptr);
 
 // Return 'true' iff the specified tablet configuration is under-replicated
 // given the 'replication_factor' and should add a replica. The decision is


### PR DESCRIPTION
Summary:

 Background: When a node in the raft ring is removed from the config,
 there is nothing in raft protocol that dictates that the removed node
 should be notified. In fact, the protocol dictates that a config change
 should be acted on immediately even before the config change itself is
 committed - this essentially means that the config change message itself
 is never sent to the node that is being removed. One should rely on
 external entities to quiesce the removed node. This has been an area of
 problem, where the removed node is not getting quiesced by external
 entities for prolonged duration and ends up starting pre-election and
 thus causing much noise in the system. Multiple fixes have gone in, but
 this still keeps happening and makes debugging a little harder. Hence
 this PR tries to address the situation by adding aggressive exponential
 backoffs when a candidate loses a pre-election. This is a little tricky
 because the protocol dictates that a voter should respond positively to
 a candidate who is not in the voter's active-config, but still presents
 the longest log (highest OpId).

 VoteResponse is enhanced to have additional voter context. For now, the
 only context is a boolen indicating if the candidate was removed from the
 voter's committed config. When a voter responds to RequestVote() rpc (either
 positively or negatively), the voter also sets this flag appropriately.

 The candidate collects this response from every voter. If any of the
 voter responds negatively and also indicates that the candidate was removed
 from the voter's committed config, then the candidate keeps track of
 this information.

 If the candidate loses the election, and if atleast one voter indicated that
 the candidate is removed from its committed config,t hen this
 information if propagated to the upper layer. Based on this information, the
 failure detector is snoozed more aggressively than in a regular ending of an
 election (starting with 5 seconds, 25 secs, 125 secs and so on and ultimately
 disabled)

Test Plan: build plugin with local tp2 and run tests

Reviewers: arahut

Subscribers:

Tasks:

Tags: