### PR TITLE
[kuduraft] checksum the payload in ReplicateMsg

### DIFF
--- a/src/kudu/consensus/consensus.proto
+++ b/src/kudu/consensus/consensus.proto
@@ -262,6 +262,10 @@ message WritePayloadPB {
   // Uncompressed size of payload. Should be present when
   // compression_codec != NO_COMPRESSION
   optional int64 uncompressed_size = 3;
+
+  // crc32 checksum of the payload. If the payload is compressed, then the
+  // checksum is computed _after_ compression
+  optional uint32 crc32 = 4 [ default = 0 ];
 }
 
 // A Replicate message, sent to replicas by leader to indicate this operation must


### PR DESCRIPTION
Summary:
The payload in WritePayloadPB is checksummed by log_cache on the leader.
The follower tries to validate the checksum in
StartFollowerTransaction(...). If a corruption is detected, then the
follower rejects the UpdateReplica(...) call with a Status::Corruption()
message.

1. The leader checksums the message only once in LogCache (and not for
   every peer individually)
2. Leader also checksums the messages that have fallen out of log-cache.
   This is done only if the request is not meant for a proxy (because
   payload is discarded anyways)
3. Proxy host also checksums the message that it needs to read from disk
4. For easier rollouts, the crc32 field in the message is defaulted to
   zero and follower will not try to validate such messages

Test Plan: tests in fbcode

Reviewers: arahut

Subscribers:

Tasks:

Tags: