### PR TITLE
[kuduraft] [proxy] auto generate proxy topology using raft configs

### DIFF
--- a/src/kudu/consensus/consensus_peers-test.cc
+++ b/src/kudu/consensus/consensus_peers-test.cc
@@ -109,6 +109,14 @@ class ConsensusPeersTest : public KuduTest {
     clock_.reset(new clock::HybridClock());
     ASSERT_OK(clock_->Init());
 
+    RaftConfigPB raft_config;
+    routing_table_container_ = std::make_shared<RoutingTableContainer>(
+        ProxyPolicy::DURABLE_ROUTING_POLICY,
+        FakeRaftPeerPB(kLeaderUuid),
+        raft_config,
+        routing_table_);
+
+
     scoped_refptr<TimeManager> time_manager(new TimeManager(clock_, Timestamp::kMin));
 
     message_queue_.reset(new PeerMessageQueue(
@@ -116,7 +124,7 @@ class ConsensusPeersTest : public KuduTest {
         log_.get(),
         time_manager,
         FakeRaftPeerPB(kLeaderUuid),
-        routing_table_,
+        routing_table_container_,
         kTabletId,
         raft_pool_->NewToken(ThreadPool::ExecutionMode::SERIAL),
         MinimumOpId(),
@@ -180,6 +188,7 @@ class ConsensusPeersTest : public KuduTest {
   gscoped_ptr<FsManager> fs_manager_;
   scoped_refptr<Log> log_;
   shared_ptr<DurableRoutingTable> routing_table_;
+  shared_ptr<RoutingTableContainer> routing_table_container_;
   gscoped_ptr<ThreadPool> raft_pool_;
   gscoped_ptr<PeerMessageQueue> message_queue_;
 #ifdef FB_DO_NOT_REMOVE

--- a/src/kudu/consensus/consensus_queue.h
+++ b/src/kudu/consensus/consensus_queue.h
@@ -201,7 +201,7 @@ class PeerMessageQueue {
                    scoped_refptr<log::Log> log,
                    scoped_refptr<TimeManager> time_manager,
                    RaftPeerPB local_peer_pb,
-                   std::shared_ptr<DurableRoutingTable> routing_table,
+                   std::shared_ptr<RoutingTableContainer> routing_table_container,
                    std::string tablet_id,
                    std::unique_ptr<ThreadPoolToken> raft_pool_observers_token,
                    OpId last_locally_replicated,
@@ -651,7 +651,7 @@ class PeerMessageQueue {
   // PB containing identifying information about the local peer.
   const RaftPeerPB local_peer_pb_;
 
-  std::shared_ptr<DurableRoutingTable> routing_table_;
+  std::shared_ptr<RoutingTableContainer> routing_table_container_;
 
   // The id of the tablet.
   const std::string tablet_id_;

--- a/src/kudu/consensus/proxy_policy.h
+++ b/src/kudu/consensus/proxy_policy.h
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+namespace kudu {
+namespace consensus {
+
+enum class ProxyPolicy {
+  // Proxy is disabled and the leader ships ops to all peers directly
+  DISABLE_PROXY = 1,
+  // Proxy routing is built implicily using current active raft configs.
+  // One peer is choosen to act as a 'proxy peer' in a given region.
+  // The rules used to build proxy topology in this policy is:
+  // 1. A given region has at-most one valid proxy peer.
+  // 2. The proxy peer in a region is always backed by a database i.e a peer
+  //    that acts as a witness (of raft log) cannot be a proxy peer.
+  // 3. A region can have no valid proxy peers, in which case the leader ships
+  //    ops directly to all peers in that region.
+  // 4. peers that get proxied through an intermediate (proxy) peer should
+  //    not be backed by a database.
+  // 5. Leader ships ops to all peers in its own region i.e no proxying in
+  //    leader's region.
+  SIMPLE_REGION_ROUTING_POLICY = 2,
+  // Routing topology needs to be explicilty supplied by external entities
+  // Read DurableRoutingTable in routing.h/routing.cc for more details
+  DURABLE_ROUTING_POLICY = 3,
+};
+} // namespace consensus
+} // namespace kudu

--- a/src/kudu/tserver/simple_tablet_manager.cc
+++ b/src/kudu/tserver/simple_tablet_manager.cc
@@ -39,6 +39,7 @@
 #include "kudu/consensus/consensus_meta.h"
 #include "kudu/consensus/consensus_meta_manager.h"
 #include "kudu/consensus/consensus_peers.h"
+#include "kudu/consensus/proxy_policy.h"
 #include "kudu/consensus/time_manager.h"
 #include "kudu/consensus/log.h"
 #include "kudu/consensus/log_util.h"
@@ -428,6 +429,8 @@ Status TSTabletManager::SetupRaft() {
 
   ConsensusOptions options;
   options.tablet_id = kSysCatalogTabletId;
+  options.proxy_policy = server_->opts().proxy_policy;
+
   shared_ptr<RaftConsensus> consensus;
   TRACE("Creating consensus");
   LOG(INFO) << LogPrefix(kSysCatalogTabletId) << "Creating Raft for the system tablet";

--- a/src/kudu/tserver/tablet_server_options.h
+++ b/src/kudu/tserver/tablet_server_options.h
@@ -21,6 +21,7 @@
 #include <memory>
 
 #include "kudu/consensus/metadata.pb.h"
+#include "kudu/consensus/proxy_policy.h"
 #include "kudu/server/server_base_options.h"
 #include "kudu/util/net/net_util.h"
 
@@ -59,6 +60,9 @@ struct TabletServerOptions : public kudu::server::ServerBaseOptions {
   std::shared_ptr<kudu::log::LogFactory> log_factory;
 
   kudu::consensus::ConsensusRoundHandler *round_handler = nullptr;
+
+  kudu::consensus::ProxyPolicy proxy_policy =
+    kudu::consensus::ProxyPolicy::DURABLE_ROUTING_POLICY;
 
   // Election Decision Callback
   std::function<void(const consensus::ElectionResult&,


### PR DESCRIPTION
Summary:
Manual updation of proxy topology (by external automation) needs proper
coordination across different systems as and when new peers are added,
removed or modified. Failure handling becomes tricky and difficult. So, it was
decided that it is better to  generate 'proxy topology' and routing
tables based on simple rules through raft configs. The routing rules
gets updated automatically when new config are proposed by the leader. This PR
tries to implement the same.

Different routing policies are defined in proxy_policy.h. There are two
policies that are defined and implemented:
1. Durable routing policy - existing policy where the routing topology
   is explicitly specified by external entities.
2. Simple region based routing policy - A new rule based proxy routing. It
   tries to keep parity with current vanilla deployment. At a high level,
   the rules used are:
 a) Each region has at most one designated 'proxy_peer' - it is chosen to be the
    peer which has a backing database. Leader ships messages to this
    'proxy_peer' when it has to send messages to any other peer in this
    region.
 b) Some regions may not have a 'proxy_peer'. Leader ships messages
    directly to all peers in such regions.
 c) There could be multiple 'candidate' proxy_peers in a given region - only
    one is chosen to be the real 'proxy_peer' for the region. This
    should not be required when region splitting is eventually
    implemented.
 d) When a new peer is added, we do not change any existing peer's proxy
    routing. This is to avoid churns in stable proxy routes on unrelated
    config changes

Implementation Notes:
1. An interface is defined through "IRoutingTable". The interface needs to be
implemented to support various routing policies.
2. A container holding all the roting policies is intantiated during
startup.
3. The policy can be shifted dynamically.

The container method was used to avoid additional locking overhead while
also supporting dynamic changes to proxy policy. The default policy is retained
to be 'DurableRoutingPolicy' to make it compatible with existing
implementation.

As the name suggests, DurableRoutingTable is persisted in cmeta - hence it is
continued to be instantiated and owned by cmeta_manager.
SimpleRegionRoutingTable is not persisted and is rebuilt using configs
on-the-fly. Hence it need not be managed by cmeta_manager.

Rules for SimpleRegionRoutingPolicy should get us a long way into
production deployment. In future, we could implement new policy with
rules for 'region-proying-another-region' to reduce cross region traffic (for
example cross atlantic traffic). If an external entity needs to implant (and
override) a topology, then the policy needs to be changed.
SimpleRegionRoutingPolicy is not persisted and hence it does not make sense to
allow external entities to provide/override arbitrary routing topology.

Test Plan: Tests in fbcode

Reviewers: arahut, mpercy

Subscribers:

Tasks:

Tags: