### PR TITLE
[kuduraft] implement proxy node health checks in leader

### DIFF
--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -256,6 +256,15 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   // Update the proxy policy used to route entries
   Status SetProxyPolicy(const ProxyPolicy& proxy_policy);
 
+  // Set the failure threshold (in milliseconds) beyond which the leader will
+  // mark a 'proxy_peer' as being unhealthy (for acting as a proxy)
+  void SetProxyFailureThreshold(int32_t proxy_failure_threshold_ms);
+
+  // Set the failure threshold lag (in term of #ops as compared to destination
+  // peer) beyond which the leader will mark a 'proxy_peer' as being unhealthy
+  // (for acting as a proxy for a given destination peer)
+  void SetProxyFailureThresholdLag(int64_t proxy_failure_threshold_lag);
+
   // Emulates an election by increasing the term number and asserting leadership
   // in the configuration by sending a NO_OP to other peers.
   // This is NOT safe to use in a distributed configuration with failure detection


### PR DESCRIPTION
Summary:
When proxying is enabled, leader ships messages to the destination nodes
througha  configured 'proxy' node. In such a setup, failure of proxy
nodes means that the destination nodes wont be able to get any messages
from the leader until the proxy recovers. This is not ideal.

This PR tries to address this situation by tracking proxy health on the
leader node. Before shipping messages through proxy, leader checks for
the proxy node's health. If it is not deemed healthy, then the leader
ships messages directly to the destination node.

The health of the proxy node is determined through two thresholds:
1. Last succesful communication that the leader had with a proxy node. The
   threshold is defaulted to (2 * election timeout). If the leader has
   not communicated with the peer for more than this threshold, then the
   peer is marked unhealthy and cannot act as a proxy
2. The comparitive lag (in terms of #ops) between the destination peer
   and the proxy peer. This threshold is defaulted to 1000 ops. If the
   proxy peer is lagging by atleast 'threshold' ops as compared to
   destination peer, then the proxy peer is marked unhealthy and cannot
   act as a proxy

Note that this mechanism does not support multi hop proxying since only the
leader knows the health of all the peers. It can be enhanced in the future
where the leader periodically exchanges the health report of all other nodes
either through UpdateReplica() RPC or a new RPC. The current simple
solution should cover us until multi hop proxying is needed for
scenarios like 'region-proxying-another-region'.

Another small enhancement made in this PR is to consolidate determining
the proxy node inside PeerMessageQueue::RequestForPeer(). This method
now returns the 'next_hop_uuid', so that the caller
(Peer::SendNextRequest()) does not have to make another call just to
find the next_hop_uuid. This reduces additional locking in this hot path

Test Plan: tests in fbcode

Reviewers: arahut

Subscribers:

Tasks:

Tags:
