### PR TITLE
Adding ability to enable/disable voter distribution adjustment

### DIFF
--- a/src/kudu/consensus/consensus_queue.h
+++ b/src/kudu/consensus/consensus_queue.h
@@ -429,6 +429,11 @@ class PeerMessageQueue {
   bool HasProxyPeerFailedUnlocked(
       const TrackedPeer* proxy_peer, const TrackedPeer* dest_peer);
 
+  void SetAdjustVoterDistribution(bool val) {
+    std::lock_guard<simple_spinlock> lock(queue_lock_);
+    adjust_voter_distribution_ = val;
+  }
+
  private:
   FRIEND_TEST(ConsensusQueueTest, TestQueueAdvancesCommittedIndex);
   FRIEND_TEST(ConsensusQueueTest, TestQueueMovesWatermarksBackward);
@@ -675,6 +680,9 @@ class PeerMessageQueue {
   const std::string tablet_id_;
 
   QueueState queue_state_;
+
+  // Should we adjust voter distribution based on current config?
+  bool adjust_voter_distribution_;
 
   // The currently tracked peers.
   PeersMap peers_map_;

--- a/src/kudu/consensus/leader_election.h
+++ b/src/kudu/consensus/leader_election.h
@@ -139,8 +139,10 @@ class FlexibleVoteCounter : public VoteCounter {
  public:
   FlexibleVoteCounter(
       const std::string& candidate_uuid,
-      int64_t election_term, const LastKnownLeaderPB& last_known_leader,
-      RaftConfigPB config);
+      int64_t election_term,
+      const LastKnownLeaderPB& last_known_leader,
+      RaftConfigPB config,
+      bool adjust_voter_distribution);
 
   // Synchronization is done by the LeaderElection class. Therefore, VoteCounter
   // class doesn't need to take care of thread safety of its book-keeping
@@ -334,6 +336,9 @@ class FlexibleVoteCounter : public VoteCounter {
 
   // Mapping from each region to number of active voters.
   std::map<std::string, int> voter_distribution_;
+
+  // Should we adjust voter distribution based on current config?
+  const bool adjust_voter_distribution_;
 
   // Vote count per region.
   std::map<std::string, int> yes_vote_count_, no_vote_count_;

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -271,6 +271,9 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   // Rejects AppendEntries RPCs, if set to true.
   void SetRejectAppendEntriesForTests(bool reject_append_entries);
 
+  // If set to false we won't adjust voter distribution based on current config
+  void SetAdjustVoterDistribution(bool val);
+
   // Update the proxy policy used to route entries
   Status SetProxyPolicy(const ProxyPolicy& proxy_policy);
 
@@ -1166,6 +1169,9 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
 
   // This is used in tests to reject AppendEntries RPC requests.
   bool reject_append_entries_;
+
+  // Should we adjust voter distribution based on current config?
+  bool adjust_voter_distribution_;
 
   // This is used in tests to reject RequestVote RPC requests.
   bool withhold_votes_;


### PR DESCRIPTION
Adding an ability to disable voter distribution adjustment based on current config. By default in flexi-raft, we always use max(voter dist, current config) to calculate the  number of votes required during an election. In this change we add an ability to disable this and use voter distribution only. It will be used to dynamically change the number of votes required in cases where the ring is broken and we cannot get enough votes to run a regular leader election.