### PR TITLE
[kuduraft] more metric for trx size

### DIFF
--- a/src/kudu/consensus/log_cache.h
+++ b/src/kudu/consensus/log_cache.h
@@ -286,6 +286,13 @@ class LogCache {
     // Keeps track of uncompressed size of messages cached. This will be same as
     // log_cache_size if compression is not enabled and on secondaries
     scoped_refptr<AtomicGauge<int64_t> > log_cache_msg_size;
+
+    // Payload size of the msg that is written to the log
+    scoped_refptr<Counter> log_cache_payload_size;
+
+    // Payload size of the compressed msg payload that is sent over the wire
+    // If compression is disabled, it is the same as log_cache_payload_size
+    scoped_refptr<Counter> log_cache_compressed_payload_size;
   };
   Metrics metrics_;
 


### PR DESCRIPTION
Summary:
Adds more metric for compressed and uncompressed trx payload size. This
can be used as additional metric to verify and validate compression ratios that are
observed in prod deployment. Uncompressed size is what is written to the local log. 
Compressed size is what is shipped over the wire.

Test Plan:

Reviewers: arahut, mpercy

Subscribers:

Tasks:

Tags: