### PR TITLE
Handle allow_start_election not being present in persistent_vars

### DIFF
--- a/src/kudu/consensus/persistent_vars.cc
+++ b/src/kudu/consensus/persistent_vars.cc
@@ -39,7 +39,8 @@ using strings::Substitute;
 
 bool PersistentVars::is_start_election_allowed() const {
   DFAKE_SCOPED_RECURSIVE_LOCK(fake_lock_);
-  DCHECK(pb_.has_allow_start_election());
+  // allow_start_election is optional with default = true
+  // So if it not present, we will allow start elections by default
   return pb_.allow_start_election();
 }
 


### PR DESCRIPTION
Since allow_start_election in persistent_vars is optional, if it is not present, we should still allow elections to be started on a peer by default.