### PR TITLE
Handle persistent vars file not present during Tablet Server Load

### DIFF
--- a/src/kudu/consensus/persistent_vars.cc
+++ b/src/kudu/consensus/persistent_vars.cc
@@ -108,6 +108,10 @@ Status PersistentVars::Load(FsManager* fs_manager,
   return Status::OK();
 }
 
+bool PersistentVars::FileExists(FsManager* fs_manager, const std::string& tablet_id) {
+  return fs_manager->env()->FileExists(fs_manager->GetPersistentVarsPath(tablet_id));
+}
+
 std::string PersistentVars::LogPrefix() const {
   // No need to lock to read const members.
   return Substitute("T $0 P $1: ", tablet_id_, peer_uuid_);

--- a/src/kudu/consensus/persistent_vars.h
+++ b/src/kudu/consensus/persistent_vars.h
@@ -80,6 +80,9 @@ class PersistentVars : public RefCountedThreadSafe<PersistentVars> {
                      const std::string& peer_uuid,
                      scoped_refptr<PersistentVars>* persistent_vars_out = nullptr);
 
+  // Check whether the persistent_vars file exists for the given tablet
+  static bool FileExists(FsManager* fs_manager, const std::string& tablet_id);
+
   std::string LogPrefix() const;
 
   FsManager* const fs_manager_;

--- a/src/kudu/consensus/persistent_vars_manager.cc
+++ b/src/kudu/consensus/persistent_vars_manager.cc
@@ -87,5 +87,9 @@ Status PersistentVarsManager::LoadPersistentVars(const string& tablet_id,
   return Status::OK();
 }
 
+bool PersistentVarsManager::PersistentVarsFileExists(const std::string& tablet_id) const {
+  return PersistentVars::FileExists(fs_manager_, tablet_id);
+}
+
 } // namespace consensus
 } // namespace kudu

--- a/src/kudu/consensus/persistent_vars_manager.h
+++ b/src/kudu/consensus/persistent_vars_manager.h
@@ -59,6 +59,9 @@ class PersistentVarsManager : public RefCountedThreadSafe<PersistentVarsManager>
   Status LoadPersistentVars(const std::string& tablet_id,
                    scoped_refptr<PersistentVars>* persistent_vars_out = nullptr);
 
+  // Check whether the Persistent Vars file exists for a given tablet
+  bool PersistentVarsFileExists(const std::string& tablet_id) const;
+
 private:
   friend class RefCountedThreadSafe<PersistentVarsManager>;
 


### PR DESCRIPTION
In case we are loading the Tablet Server i.e. it's not the first run, we should not expect the persistent vars to be already created. If it is not present, we should create the file first before attempting to load it.