### PR TITLE
[kuduraft] [proxy] explicitly clear proxy uuid from the request object

### DIFF
--- a/src/kudu/consensus/consensus_queue.cc
+++ b/src/kudu/consensus/consensus_queue.cc
@@ -779,7 +779,12 @@ Status PeerMessageQueue::RequestForPeer(const string& uuid,
   // If the next hop != the destination, we are sending these messages via a proxy.
   bool route_via_proxy = *next_hop_uuid != uuid;
   if (route_via_proxy) {
+    // Set proxy uuid
     request->set_proxy_dest_uuid(*next_hop_uuid);
+  } else {
+    // Clear proxy uuid to ensure that this message is not rejected by the
+    // destination
+    request->clear_proxy_dest_uuid();
   }
 
   // If we've never communicated with the peer, we don't know what messages to

--- a/src/kudu/consensus/log_cache.cc
+++ b/src/kudu/consensus/log_cache.cc
@@ -619,14 +619,15 @@ Status LogCache::BlockingReadOps(int64_t after_op_index,
 
   {
     std::lock_guard<Mutex> l(lock_);
-    while (after_op_index >= next_sequential_op_index_) {
+
+    while ((after_op_index + 1) >= next_sequential_op_index_) {
       (void) next_index_cond_.WaitUntil(deadline);
 
       if (MonoTime::Now() > deadline)
         break;
     }
 
-    if (after_op_index >= next_sequential_op_index_) {
+    if ((after_op_index + 1) >= next_sequential_op_index_) {
       // Waited for max_duration_ms, but 'after_op_index' is still not available
       // in the local log
       return Status::Incomplete(Substitute("Op with index $0 is ahead of the local log "


### PR DESCRIPTION
Summary:
There are two fixes in this PR - the first one is on the leader when
building the proxy request and the second is on the proxy node when
reading the ops from log/log-cache.

1. The recipient of a consensus request message determines if the
request is a 'proxy' request by checking the 'proxy_dest_uuid' field of
the request. When this is set, then the message is a proxy request.
Based on this fact, this message will be rejected if
'proxy_dest_uuid' is not the same as the recipient's uuid. This is
essentially a safeguard against misrouted proxy requests. The request object is
cached for each peer and relevant fields are rebuilt when the leader has to
send a request. When proxy gets disabled, the 'proxy_dest_uuid' field was not
cleared. The message is routed directly to the destination, but this message
has the 'proxy_dest_uuid' set to the old 'proxy_peer'. This triggers the
check mentioned above and the recipient rejects this message and will never be
able to receives any messages from the leader. This PR fixes the problem by
explicitly clearing this field when building the request on the leader.

2. The proxy node builds the real request for the destination by reading
from its own log. While reading, the ops may not be yet available in its
own log. If so, it blocks for a configured duration and then bails out
by only sending a heartbeat to the destination (with the assumption that
the leader will eventually send the ops to proxy node and send another
proxy request). There was a off-by-one bug while checking for the
condition which determines that the proxy node should block. This PR
fixes the same.

Test Plan: local tp2 checkouts and trigger this scenario in fbcode

Reviewers: arahut, mpercy

Subscribers:

Tasks:

Tags: