### PR TITLE
Adding logging for leader election duration and refreshing consensus …

### DIFF
--- a/src/kudu/consensus/leader_election.h
+++ b/src/kudu/consensus/leader_election.h
@@ -509,6 +509,9 @@ class LeaderElection : public RefCountedThreadSafe<LeaderElection> {
 
   // The highest term seen from a voter so far (or 0 if no votes).
   int64_t highest_voter_term_;
+
+  // The time when the election started
+  MonoTime start_time_;
 };
 
 } // namespace consensus


### PR DESCRIPTION
…queue on changing voter_distribution

Summary: In this PR we do 2 changes.

1. We measure the time it takes to do a round of election and log it on
decision

2. We fix an issue during the change of voter distribution from the
application, where the consensus queue was not bumped/refreshed. Without
this refresh, if we chanegd the voter distribution it would not impact
the LEADERs commit quorum. We noticed it when we increased voter
distribution to a number which would make it infeasible to commit,
the change would not reflect and the commits would keep flowing through.
This is a destructive example but represents that voter distribution
change should impact commits. This fixes that and makes the VD change
effect.

In the future, we should add another check, which disallows voter
distribution change except in Unsafe Config Change to create such a
situation.

Test Plan:

  For 1.

  I0804 23:15:14.841780 1833196 leader_election.cc:1304] T 00000000000000000000000000000000 P
  8212bbc9-e8f5-11eb-9c9c-0ff6a557c3cc [CANDIDATE]: Term 7 election: Election decided. Result: candidate won. duration: 0.164s

  For 2.

  After changing the voter distribution in a region to 15, where the
  number of voters is 6, the cursor gets stuck. The 3 values are
  low water mark, applied and committed opids's
  Cursor is expected to get stuck because for VD of 15 in FlexiRaft,
  commit quorum is 8, but there are only 6 voters.

  Output of script raft-dba status ${ring}

  host:3308 *   8212bbc9-e8f5-11eb-9c9c-0ff6a557c3cc   LEADER     7      7:10659329   7:10659329     7:10659329

  After changing the voter distribution back to 6 cursor starts moves again

  host:3308 *   8212bbc9-e8f5-11eb-9c9c-0ff6a557c3cc   LEADER     7      7:10659419   7:10659419     7:10659419

Reviewers: abhinav04sharma

Subscribers:

Tasks:

Tags: