### PR TITLE
[kuduraft] function to return proxy policy

### DIFF
--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -4300,6 +4300,25 @@ Status RaftConsensus::SetProxyPolicy(const ProxyPolicy& proxy_policy) {
       proxy_policy_, cmeta_->leader_uuid(), cmeta_->ActiveConfig());
 }
 
+void RaftConsensus::GetProxyPolicy(std::string* proxy_policy) {
+  LockGuard l(lock_);
+
+  switch (proxy_policy_) {
+    case ProxyPolicy::DISABLE_PROXY:
+      *proxy_policy = "DISABLE_PROXY";
+      break;
+    case ProxyPolicy::SIMPLE_REGION_ROUTING_POLICY:
+      *proxy_policy = "SIMPLE_REGION_ROUTING_POLICY";
+      break;
+    case ProxyPolicy::DURABLE_ROUTING_POLICY:
+      *proxy_policy = "DURABLE_ROUTING_POLICY";
+      break;
+    default:
+      *proxy_policy = "UNKNOWN";
+      break;
+  }
+}
+
 void RaftConsensus::SetProxyFailureThreshold(
     int32_t proxy_failure_threshold_ms) {
   LockGuard l(lock_);

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -277,6 +277,9 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   // Update the proxy policy used to route entries
   Status SetProxyPolicy(const ProxyPolicy& proxy_policy);
 
+  // Returns the current proxy policy in use
+  void GetProxyPolicy(std::string* proxy_policy);
+
   // Set the failure threshold (in milliseconds) beyond which the leader will
   // mark a 'proxy_peer' as being unhealthy (for acting as a proxy)
   void SetProxyFailureThreshold(int32_t proxy_failure_threshold_ms);


### PR DESCRIPTION
Summary:
Proxy policy that is being currently used is returned as a string. Used
in upper layers to display status variables.

Test Plan:
Local tp2 checkout and run with mysql

mysql> show status like 'Rpl_raft_proxy_policy';
+-----------------------+---------------+
| Variable_name         | Value         |
+-----------------------+---------------+
| Rpl_raft_proxy_policy | DISABLE_PROXY |
+-----------------------+---------------+
1 row in set (0.00 sec)

mysql> show raft status \G
....
....
....
....
*************************** 19. row ***************************
Variable_name: Rpl_raft_proxy_policy
        Value: DISABLE_PROXY
19 rows in set (0.00 sec)

Reviewers: arahut, mpercy

Subscribers:

Tasks:

Tags: