### PR TITLE
[kuduraft] degrade a unhealthy peer to 'status-only' heartbeats

### DIFF
--- a/src/kudu/consensus/consensus_queue-test.cc
+++ b/src/kudu/consensus/consensus_queue-test.cc
@@ -175,7 +175,7 @@ class ConsensusQueueTest : public KuduTest {
     vector<ReplicateRefPtr> refs;
     bool needs_tablet_copy;
     std::string next_hop_uuid;
-    ASSERT_OK(queue_->RequestForPeer(kPeerUuid, request, &refs, &needs_tablet_copy, &next_hop_uuid, &next_hop_uuid));
+    ASSERT_OK(queue_->RequestForPeer(kPeerUuid, /*read_ops=*/true, request, &refs, &needs_tablet_copy, &next_hop_uuid, &next_hop_uuid));
     ASSERT_FALSE(needs_tablet_copy);
     ASSERT_EQ(request->ops_size(), 0);
 
@@ -286,7 +286,7 @@ TEST_F(ConsensusQueueTest, TestStartTrackingAfterStart) {
   vector<ReplicateRefPtr> refs;
   bool needs_tablet_copy;
   std::string next_hop_uuid;
-  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
+  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, /*read_ops=*/true, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
   ASSERT_FALSE(needs_tablet_copy);
   ASSERT_EQ(50, request.ops_size());
 
@@ -295,7 +295,7 @@ TEST_F(ConsensusQueueTest, TestStartTrackingAfterStart) {
   ASSERT_FALSE(send_more_immediately) << "Queue still had requests pending";
 
   // if we ask for a new request, it should come back empty
-  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
+  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, /*read_ops=*/true, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
   ASSERT_FALSE(needs_tablet_copy);
   ASSERT_EQ(0, request.ops_size());
 
@@ -352,7 +352,7 @@ TEST_F(ConsensusQueueTest, TestGetPagedMessages) {
     vector<ReplicateRefPtr> refs;
     bool needs_tablet_copy;
     std::string next_hop_uuid;
-    iASSERT_OK(queue_->RequestForPeer(kPeerUuid, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
+    iASSERT_OK(queue_->RequestForPeer(kPeerUuid, /*read_ops=*/true, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
     ASSERT_FALSE(needs_tablet_copy);
     ASSERT_EQ(kOpsPerRequest, request.ops_size());
     last = request.ops(request.ops_size() -1).id();
@@ -364,7 +364,7 @@ TEST_F(ConsensusQueueTest, TestGetPagedMessages) {
   vector<ReplicateRefPtr> refs;
   bool needs_tablet_copy;
   std::string next_hop_uuid;
-  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
+  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, /*read_ops=*/true, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
   ASSERT_FALSE(needs_tablet_copy);
   ASSERT_EQ(1, request.ops_size());
   last = request.ops(request.ops_size() -1).id();
@@ -407,7 +407,7 @@ TEST_F(ConsensusQueueTest, TestPeersDontAckBeyondWatermarks) {
   vector<ReplicateRefPtr> refs;
   bool needs_tablet_copy;
   std::string next_hop_uuid;
-  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
+  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, /*read_ops=*/true, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
   ASSERT_FALSE(needs_tablet_copy);
   ASSERT_EQ(50, request.ops_size());
 
@@ -423,7 +423,7 @@ TEST_F(ConsensusQueueTest, TestPeersDontAckBeyondWatermarks) {
   ASSERT_EQ(queue_->GetAllReplicatedIndex(), 100);
 
   // if we ask for a new request, it should come back with the rest of the messages
-  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
+  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, /*read_ops=*/true, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
   ASSERT_FALSE(needs_tablet_copy);
   ASSERT_EQ(100, request.ops_size());
 
@@ -635,7 +635,7 @@ TEST_F(ConsensusQueueTest, TestQueueLoadsOperationsForPeer) {
   vector<ReplicateRefPtr> refs;
   bool needs_tablet_copy;
   std::string next_hop_uuid;
-  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
+  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, /*read_ops=*/true, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
   ASSERT_FALSE(needs_tablet_copy);
   ASSERT_EQ(request.ops_size(), 50);
 
@@ -696,7 +696,7 @@ TEST_F(ConsensusQueueTest, TestQueueHandlesOperationOverwriting) {
   // this should contain no operations.
   bool needs_tablet_copy;
   std::string next_hop_uuid;
-  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
+  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, /*read_ops=*/true, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
   ASSERT_FALSE(needs_tablet_copy);
   ASSERT_EQ(request.ops_size(), 0);
   ASSERT_OPID_EQ(request.preceding_id(), MakeOpId(2, 20));
@@ -735,7 +735,7 @@ TEST_F(ConsensusQueueTest, TestQueueHandlesOperationOverwriting) {
 
   // Generate another request for the remote peer, which should include
   // all of the ops since the peer's last-known committed index.
-  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
+  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, /*read_ops=*/true, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
   ASSERT_FALSE(needs_tablet_copy);
   ASSERT_OPID_EQ(MakeOpId(1, 5), request.preceding_id());
   ASSERT_EQ(16, request.ops_size());
@@ -862,7 +862,7 @@ TEST_F(ConsensusQueueTest, TestOnlyAdvancesWatermarkWhenPeerHasAPrefixOfOurLog) 
   // the committed index, for a total of 9 operations.
   bool needs_tablet_copy;
   std::string next_hop_uuid;
-  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
+  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, /*read_ops=*/true, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
   ASSERT_FALSE(needs_tablet_copy);
   ASSERT_EQ(request.ops_size(), 9);
   ASSERT_OPID_EQ(request.ops(0).id(), MakeOpId(72, 32));
@@ -883,7 +883,7 @@ TEST_F(ConsensusQueueTest, TestOnlyAdvancesWatermarkWhenPeerHasAPrefixOfOurLog) 
   // Another request for this peer should get another page of messages. Still not
   // on the queue's term (and thus without advancing watermarks).
   request.mutable_ops()->ExtractSubrange(0, request.ops().size(), nullptr);
-  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
+  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, /*read_ops=*/true, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
   ASSERT_FALSE(needs_tablet_copy);
   ASSERT_EQ(request.ops_size(), 9);
   ASSERT_OPID_EQ(request.ops(0).id(), MakeOpId(72, 41));
@@ -901,7 +901,7 @@ TEST_F(ConsensusQueueTest, TestOnlyAdvancesWatermarkWhenPeerHasAPrefixOfOurLog) 
   // The last page of request should overwrite the peer's operations and the
   // response should finally advance the watermarks.
   request.mutable_ops()->ExtractSubrange(0, request.ops().size(), nullptr);
-  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, &request, &refs, &needs_tablet_copyi, &next_hop_uuid));
+  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, /*read_ops=*/true, &request, &refs, &needs_tablet_copyi, &next_hop_uuid));
   ASSERT_FALSE(needs_tablet_copy);
   ASSERT_EQ(request.ops_size(), 4);
   ASSERT_OPID_EQ(request.ops(0).id(), MakeOpId(73, 50));
@@ -932,7 +932,7 @@ TEST_F(ConsensusQueueTest, TestTriggerTabletCopyIfTabletNotFound) {
   vector<ReplicateRefPtr> refs;
   bool needs_tablet_copy;
   std::string next_hop_uuid;
-  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
+  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, /*read_ops=*/true, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
   ASSERT_FALSE(needs_tablet_copy);
 
   // Peer responds with tablet not found.
@@ -941,7 +941,7 @@ TEST_F(ConsensusQueueTest, TestTriggerTabletCopyIfTabletNotFound) {
 
   // On the next request, we should find out that the queue wants us to initiate Tablet Copy.
   request.Clear();
-  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
+  ASSERT_OK(queue_->RequestForPeer(kPeerUuid, /*read_ops=*/true, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
   ASSERT_TRUE(needs_tablet_copy);
 
   StartTabletCopyRequestPB tc_req;

--- a/src/kudu/consensus/consensus_queue.cc
+++ b/src/kudu/consensus/consensus_queue.cc
@@ -694,6 +694,7 @@ Status PeerMessageQueue::FindPeer(const std::string& uuid, TrackedPeer* peer) {
 }
 
 Status PeerMessageQueue::RequestForPeer(const string& uuid,
+                                        bool read_ops,
                                         ConsensusRequestPB* request,
                                         vector<ReplicateRefPtr>* msg_refs,
                                         bool* needs_tablet_copy,
@@ -790,7 +791,11 @@ Status PeerMessageQueue::RequestForPeer(const string& uuid,
   // If we've never communicated with the peer, we don't know what messages to
   // send, so we'll send a status-only request. Otherwise, we grab requests
   // from the log starting at the last_received point.
-  if (peer_copy.last_exchange_status != PeerStatus::NEW) {
+  // If the caller has explicitly indicated to not read the ops (as indicated by
+  // 'read_ops'), then we skip reading ops from log-cache/log. The caller
+  // ususally does this when the leader detects that a peer is unhealthy and
+  // hence needs to be degraded to a 'status-only' request
+  if (peer_copy.last_exchange_status != PeerStatus::NEW && read_ops) {
 
     // The batch of messages to send to the peer.
     vector<ReplicateRefPtr> messages;

--- a/src/kudu/consensus/consensus_queue.h
+++ b/src/kudu/consensus/consensus_queue.h
@@ -293,6 +293,7 @@ class PeerMessageQueue {
   // replace the old entries with new ones without de-allocating the old
   // ones if they are still required.
   Status RequestForPeer(const std::string& uuid,
+                        bool read_ops,
                         ConsensusRequestPB* request,
                         std::vector<ReplicateRefPtr>* msg_refs,
                         bool* needs_tablet_copy,


### PR DESCRIPTION
Summary:
In raft, the leader maintains persistent state about all nodes in the ring.
Whenever a node goes down, leader will keep attempting to make connection to
this failed node as part of heartbeats (configured to be 500ms).

As part of sending a heartbeat, the leader tries to ship as many trxs as
possible (based on the batch size). The trxs to be shipped is determined based
on the leader's knowledge of the 'last-recieved-trx' by this particular failed
node. As more writes happen in the system, the failed node starts to 'lag' more.
Hence each successive attempt by the leader to connect to this particular
failed node will have to do more work - i.e read more trxs from the
log-cache/log (upto maximum configured batch size, defaulted to 2MB in MyRaft),
build the RPC message and try to push it to the failed node (which fails again,
because the node is not reachable). This is wasted work on the leader and on a
high write rate system this will soon start effecting leader's performance as
this involves opening a file, seeking to the desired op and reading 2MB
worth of data (in addition to building the request).

This PR tries to solve the problem by degrading the failed peer to a
'status-only' heartbeat request. What this essentially does is skipping
building the ops by reading from the log. Leader already tracks
'failed_attempts' i.e number of consecutive failure on communicating with a
peer. Based on this knowledge, leader determines that the peer should be
degraded to 'status-only' heartbeat request. When the leader is able to
communicate successfully with the peer again, 'failed_attempts' counter
is reset and the leader starts shipping ops again transparently to this
peer again.

Test Plan:
Tested in mysql mtr. Simulated a scenario where one of the peers failed
in a three ring setup. Ensured that the leader will stop shipping ops to
the failed peer and degrade to status-only heartbeat requests. The
leader is still able to commit ops because of the votes from the healthy
peer. When the failed peer recovers, leader transparently started
shipping ops again and caught up the recovered peer.

Reviewers: arahut

Subscribers:

Tasks:

Tags: