### PR TITLE
Adding server_id to RaftPeerAttrsPB

### DIFF
--- a/src/kudu/consensus/metadata.proto
+++ b/src/kudu/consensus/metadata.proto
@@ -42,9 +42,12 @@ message RaftPeerAttrsPB {
 
   // Geographic region of the raft server.
   optional string region = 4;
-  
+
   // The port on which the logtailer server for a BLS peer is running
   optional int32 logtailer_server_port = 5 [ default = 0 ];
+
+  // The mysql/bls server id
+  optional uint32 server_id = 6 [ default = 0 ];
 }
 
 // Report on a replica's (peer's) health.


### PR DESCRIPTION
Summary: server_id is a unique uint32 member maintained by MySQL and
BLS. This field will be used to update follower info on MySQL side.

Test Plan: N/A

Reviewers: arahut, yashb, vinaybhat, chili