### PR TITLE
[peer-management] [FR] [1/n]  perf enhancements in peer management

### DIFF
--- a/src/kudu/consensus/consensus_peers.h
+++ b/src/kudu/consensus/consensus_peers.h
@@ -204,7 +204,7 @@ class Peer : public std::enable_shared_from_this<Peer> {
 
   // lock that protects Peer state changes, initialization, etc.
   mutable simple_spinlock peer_lock_;
-  bool request_pending_ = false;
+  std::atomic<bool> request_pending_;
   bool closed_ = false;
   bool has_sent_first_request_ = false;
 

--- a/src/kudu/consensus/consensus_queue.cc
+++ b/src/kudu/consensus/consensus_queue.cc
@@ -968,6 +968,16 @@ void PeerMessageQueue::AdvanceQueueRegionDurableIndex() {
     queue_state_.region_durable_index, max_region_durable_index);
 }
 
+boost::optional<QuorumMode> PeerMessageQueue::GetQuorumMode() const {
+  std::lock_guard<simple_spinlock> lock(queue_lock_);
+  if (!FLAGS_enable_flexi_raft ||
+      !queue_state_.active_config->has_commit_rule()) {
+    return boost::none;
+  }
+
+  return queue_state_.active_config->commit_rule().mode();
+}
+
 void PeerMessageQueue::AdvanceQueueWatermark(const char* type,
                                              int64_t* watermark,
                                              const OpId& replicated_before,

--- a/src/kudu/consensus/consensus_queue.h
+++ b/src/kudu/consensus/consensus_queue.h
@@ -413,6 +413,10 @@ class PeerMessageQueue {
     return &log_cache_;
   }
 
+  // Fetch the quorum mode. returns boost::none when FlexiRaft is not enabled
+  // OR when the queue state is not provided with a commit rule
+  boost::optional<QuorumMode> GetQuorumMode() const;
+
   // Set the threshold (in milliseconds) that is used to determine the health of
   // the 'proxy peer'
   void SetProxyFailureThreshold(int32_t proxy_failure_threshold_ms);

--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -422,6 +422,7 @@ Status RaftConsensus::Start(const ConsensusBootstrapInfo& info,
   // and to the local wal.
   unique_ptr<PeerManager> peer_manager(new PeerManager(options_.tablet_id,
                                                        peer_uuid(),
+                                                       peer_region(),
                                                        peer_proxy_factory_.get(),
                                                        queue.get(),
                                                        raft_pool_token_.get(),
@@ -3037,7 +3038,9 @@ Status RaftConsensus::RefreshConsensusQueueAndPeersUnlocked() {
   queue_->SetLeaderMode(pending_->GetCommittedIndex(),
                         CurrentTermUnlocked(),
                         active_config);
-  RETURN_NOT_OK(peer_manager_->UpdateRaftConfig(active_config));
+  RETURN_NOT_OK(peer_manager_->UpdateRaftConfig(
+        active_config,
+        queue_->GetQuorumMode()));
   return Status::OK();
 }
 


### PR DESCRIPTION
Summary:
While FlexiRaft adds the flexibility of having a smaller data commit
quorum (for faster commits) and a wider leader election quorum (for more
failover options), the underlying data structures are still shared by all
the peers. This creates contention points as the number of peers in the
ring grows.

This PR is a first step in splitting the underlying data structures which are
responsible for managing different peers and queues. The rationale is
that this will reduce contention in these shared data structures.

There are two major changes in this PR

1. PeerManager to have two different lists of peers:
PeerManager manages a list of peers. Whenever an operation needs to be
replicated, RaftConsensus::Replicate() calls into
PeerManager::SignalRequest() to start this process.
PeerManager::SignalRequest() is also called when the commit index moves
forward (RaftConsensus::NotifyCommitIndex(...)). This PR makes PeerManager
manage two different lists - one for peers that are in data commit
quorum and the other for everything else. PeerManager::SignalRequest() tries to
build the request first for all the members in data commit quorum and
follows it up by building the same for other peers. This ensures that
any lagging peer that is not in the critical path of committing a trx
will not block out commits. Note that the determination of a peer being a
member of data commit quorum is tightly coupled with the concept of
'leader region' in SINGLE_REGION_DYNAMIC mode of FR. Hence this 
optimization is possible only in this mode.

2. Enhancements to "request_pending" tracker of the Peer:
For every peer, the leader  tracks if a request is pending i.e a request is in
flight for this particular peer. There can only be one outstanding request for
a peer. This PR changes the semantics of 'request_pending' to mean 'request
is being built' (instead of 'request is in flight'). Building a request
could be expensive for a lagging peer as it need to do disk IO. This
could block threads which are holding onto RaftConsensus::lock_ and
PeerManager::lock_, thus blocking out the commit process completely.
This PR makes it so that when a request is being built (i.e
Peer::SendNextRequest(...) calls into PeerMessageQueue::RequestForPeer()), we
return early when attempting to build another request for the same peer.
The rationale is that if there are multiple calls into
Peer::SendNextRequest() (from different callsites), then there is no
need to build duplicate requests for this particular peer. Any
additional operations can always be shipped in a subsequent batch. To
make this check lock-free, "request_pending_" is made an atomic.
This ensures that  RaftConsensus::lock_ and PeerManager::lock_ are not locked
for an extended duration

Future enhancements:
1. It is not clear why the advancement of commit index (on the leader)
should trigger a round of PeerManager::SignalRequest(). In a subsequent
PR, we can try avoiding calling PeerManager::SignalRequest() (from
RaftConsensus::NotifyCommitIndex()). We can even make it so that we only build
requests for peers in data commit quorum - the rest of the peers can get
requests when replicating the next operation OR the next heartbeat.
2. PeerMessageQueue() is another data structure which could use some
enhancements to better support FR topologies.

Test Plan:
1. tests in fbcode
2. pending perf tests

Reviewers:

Subscribers:

Tasks:

Tags: