### PR TITLE
[time-manager] ability to disable time manager features in kudu

### DIFF
--- a/src/kudu/consensus/consensus_queue.cc
+++ b/src/kudu/consensus/consensus_queue.cc
@@ -174,7 +174,7 @@ PeerMessageQueue::Metrics::Metrics(const scoped_refptr<MetricEntity>& metric_ent
 
 PeerMessageQueue::PeerMessageQueue(const scoped_refptr<MetricEntity>& metric_entity,
                                    scoped_refptr<log::Log> log,
-                                   scoped_refptr<TimeManager> time_manager,
+                                   scoped_refptr<ITimeManager> time_manager,
                                    RaftPeerPB local_peer_pb,
                                    std::shared_ptr<RoutingTableContainer> routing_table_container,
                                    string tablet_id,

--- a/src/kudu/consensus/consensus_queue.h
+++ b/src/kudu/consensus/consensus_queue.h
@@ -199,7 +199,7 @@ class PeerMessageQueue {
 
   PeerMessageQueue(const scoped_refptr<MetricEntity>& metric_entity,
                    scoped_refptr<log::Log> log,
-                   scoped_refptr<TimeManager> time_manager,
+                   scoped_refptr<ITimeManager> time_manager,
                    RaftPeerPB local_peer_pb,
                    std::shared_ptr<RoutingTableContainer> routing_table_container,
                    std::string tablet_id,
@@ -703,7 +703,7 @@ class PeerMessageQueue {
 
   Metrics metrics_;
 
-  scoped_refptr<TimeManager> time_manager_;
+  scoped_refptr<ITimeManager> time_manager_;
 
   // Duration in milliseconds before a peer is marked as 'failed' to being a
   // proxy-peer.

--- a/src/kudu/consensus/pending_rounds.cc
+++ b/src/kudu/consensus/pending_rounds.cc
@@ -46,7 +46,7 @@ namespace consensus {
 // PendingRounds
 //------------------------------------------------------------
 
-PendingRounds::PendingRounds(string log_prefix, scoped_refptr<TimeManager> time_manager)
+PendingRounds::PendingRounds(string log_prefix, scoped_refptr<ITimeManager> time_manager)
     : log_prefix_(std::move(log_prefix)),
       last_committed_op_id_(MinimumOpId()),
       time_manager_(std::move(time_manager)) {}

--- a/src/kudu/consensus/pending_rounds.h
+++ b/src/kudu/consensus/pending_rounds.h
@@ -30,7 +30,7 @@ class Status;
 
 namespace consensus {
 class ConsensusRound;
-class TimeManager;
+class ITimeManager;
 
 // Tracks the pending consensus rounds being managed by a Raft replica (either leader
 // or follower).
@@ -41,7 +41,7 @@ class TimeManager;
 // We should consolidate to "round".
 class PendingRounds {
  public:
-  PendingRounds(std::string log_prefix, scoped_refptr<TimeManager> time_manager);
+  PendingRounds(std::string log_prefix, scoped_refptr<ITimeManager> time_manager);
   ~PendingRounds();
 
   // Set the committed op during startup. This should be done after
@@ -109,7 +109,7 @@ class PendingRounds {
   // The OpId of the round that was last committed. Initialized to MinimumOpId().
   OpId last_committed_op_id_;
 
-  scoped_refptr<TimeManager> time_manager_;
+  scoped_refptr<ITimeManager> time_manager_;
 
   DISALLOW_COPY_AND_ASSIGN(PendingRounds);
 };

--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -345,7 +345,7 @@ Status RaftConsensus::Create(ConsensusOptions options,
 Status RaftConsensus::Start(const ConsensusBootstrapInfo& info,
                             gscoped_ptr<PeerProxyFactory> peer_proxy_factory,
                             scoped_refptr<log::Log> log,
-                            scoped_refptr<TimeManager> time_manager,
+                            scoped_refptr<ITimeManager> time_manager,
                             ConsensusRoundHandler* round_handler,
                             const scoped_refptr<MetricEntity>& metric_entity,
                             Callback<void(const std::string& reason)> mark_dirty_clbk) {
@@ -354,6 +354,7 @@ Status RaftConsensus::Start(const ConsensusBootstrapInfo& info,
   peer_proxy_factory_ = std::move(peer_proxy_factory);
   log_ = std::move(log);
   time_manager_ = std::move(time_manager);
+
   round_handler_ = DCHECK_NOTNULL(round_handler);
   mark_dirty_clbk_ = std::move(mark_dirty_clbk);
 

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -228,7 +228,7 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   Status Start(const ConsensusBootstrapInfo& info,
                gscoped_ptr<PeerProxyFactory> peer_proxy_factory,
                scoped_refptr<log::Log> log,
-               scoped_refptr<TimeManager> time_manager,
+               scoped_refptr<ITimeManager> time_manager,
                ConsensusRoundHandler* round_handler,
                const scoped_refptr<MetricEntity>& metric_entity,
                Callback<void(const std::string& reason)> mark_dirty_clbk);
@@ -524,7 +524,7 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   // Thread-safe.
   const std::string& tablet_id() const;
 
-  scoped_refptr<TimeManager> time_manager() const { return time_manager_; }
+  scoped_refptr<ITimeManager> time_manager() const { return time_manager_; }
 
   // Return the minimum election timeout. Due to backoff and random
   // jitter, election timeouts may be longer than this.
@@ -1124,7 +1124,7 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   std::unique_ptr<ThreadPoolToken> raft_pool_token_;
 
   scoped_refptr<log::Log> log_;
-  scoped_refptr<TimeManager> time_manager_;
+  scoped_refptr<ITimeManager> time_manager_;
   gscoped_ptr<PeerProxyFactory> peer_proxy_factory_;
 
   // When we receive a message from a remote peer telling us to start a

--- a/src/kudu/consensus/time_manager.cc
+++ b/src/kudu/consensus/time_manager.cc
@@ -294,7 +294,7 @@ bool TimeManager::IsTimestampSafeUnlocked(Timestamp timestamp) {
   return timestamp <= GetSafeTimeUnlocked();
 }
 
-Timestamp TimeManager::GetSafeTime()  {
+Timestamp TimeManager::GetSafeTime() {
   Lock l(lock_);
   return GetSafeTimeUnlocked();
 }
@@ -355,7 +355,6 @@ Timestamp TimeManager::GetSerialTimestampUnlocked() {
 Timestamp TimeManager::GetSerialTimestampPlusMaxError() {
   return clock_->NowLatest();
 }
-
 
 } // namespace consensus
 } // namespace kudu

--- a/src/kudu/tserver/tablet_server_options.h
+++ b/src/kudu/tserver/tablet_server_options.h
@@ -85,6 +85,9 @@ struct TabletServerOptions : public kudu::server::ServerBaseOptions {
 
   consensus::TopologyConfigPB topology_config;
 
+  // Enables functionality provided by kudu::consensus::TimeManager
+  bool enable_time_manager = true;
+
   bool IsDistributed() const;
 };
 


### PR DESCRIPTION
Summary:
This is mostly used in kudu for HLC support which we are not making use
of. This avoids dependency on NTP clock synchronization and also avoid
taking some hot locks.

Test Plan:
tests in fbcode

Reviewers: arahut

Subscribers:

Tasks:

Tags: