### PR TITLE
[perf] [1/n] enhance 'request-pending' logic in consensus_peer

### DIFF
--- a/src/kudu/consensus/consensus_peers.h
+++ b/src/kudu/consensus/consensus_peers.h
@@ -204,7 +204,7 @@ class Peer : public std::enable_shared_from_this<Peer> {
 
   // lock that protects Peer state changes, initialization, etc.
   mutable simple_spinlock peer_lock_;
-  bool request_pending_ = false;
+  std::atomic<bool> request_pending_;
   bool closed_ = false;
   bool has_sent_first_request_ = false;
 


### PR DESCRIPTION
Summary:
Enhancements to "request_pending" tracker of the Peer:
For every peer, the leader tracks if a request is pending i.e a request is in
flight for this particular peer. There can only be one outstanding request for
a peer. This PR changes the semantics of 'request_pending' to mean 'request
is being built and/or request is in flight' (instead of 'request is in flight'). Building
a request could be expensive for a lagging peer as it need to do disk IO. This
could block threads which are holding onto RaftConsensus::lock_ and
PeerManager::lock_, thus blocking out the commit process completely.
This PR makes it so that when a request is being built (i.e
Peer::SendNextRequest(...) calls into PeerMessageQueue::RequestForPeer()), we
return early when attempting to build another request for the same peer.
The rationale is that if there are multiple calls into
Peer::SendNextRequest() (from different callsites), then there is no
need to build duplicate requests for this particular peer. Any
additional operations can always be shipped in a subsequent batch. To
make this check lock-free, "request_pending_" is made an atomic.
This ensures that RaftConsensus::lock_ and PeerManager::lock_ are not locked
for an extended duration

Test Plan: fbcode tests and perf tests

Reviewers: arahut

Subscribers:

Tasks:

Tags: