### PR TITLE
[rpc-reactor] [perf] [2/n] ability to configure number of reactor threads

### DIFF
--- a/src/kudu/server/rpc_server.h
+++ b/src/kudu/server/rpc_server.h
@@ -53,6 +53,7 @@ struct RpcServerOptions {
   uint16_t default_port;
   size_t service_queue_length;
   bool rpc_reuseport;
+  uint32_t num_reactor_threads;
 };
 
 class RpcServer {

--- a/src/kudu/server/server_base.cc
+++ b/src/kudu/server/server_base.cc
@@ -493,6 +493,12 @@ Status ServerBase::Init() {
     builder.set_reuseport();
   }
 
+  // If rpc_opts explicitly specify the number of reactor threads, then use it
+  // to override FLAGS_num_reactor_threads
+  if (options_.rpc_opts.num_reactor_threads != 0) {
+    builder.set_num_reactors(options_.rpc_opts.num_reactor_threads);
+  }
+
   RETURN_NOT_OK(builder.Build(&messenger_));
   rpc_server_->set_too_busy_hook(std::bind(
       &ServerBase::ServiceQueueOverflowed, this, std::placeholders::_1));


### PR DESCRIPTION
Summary:
This is needed when the number of peers in the ring is large. If the
value is specified in rpc options, then use it to override the value
specified through gflag.

Future steps:
1. Having more threads in learners/witness/secondaries is not really
useful. We could think of dynamically changing the number of reactor
threads as the ring goes through promotions and config changes.
2. Add support to create and destroy reactor threads during run time
(this will also help with 1)
3. Use different thread pools for reactor threads that serve peers which
are part of data commit quorum. This way thread priorities can be set
differently

Test Plan: tests in fbcode

Reviewers: arahut

Subscribers:

Tasks:

Tags: