### PR TITLE
Adding a function to dump the current certificates into a string vector

### DIFF
--- a/src/kudu/rpc/negotiation.cc
+++ b/src/kudu/rpc/negotiation.cc
@@ -331,7 +331,8 @@ void Negotiation::RunNegotiation(const scoped_refptr<Connection>& conn,
     Status reload_status = tls_context->LoadCertFiles(
         FLAGS_rpc_ca_certificate_file,
         FLAGS_rpc_certificate_file,
-        FLAGS_rpc_private_key_file);
+        FLAGS_rpc_private_key_file,
+        FLAGS_create_new_x509_store_each_time);
     TRACE("SSL context certificate store refreshed : $0", reload_status.ToString());
   }
 


### PR DESCRIPTION
Summary: Also modifying LoadCertFiles to take in a parameter
for use_new_store, which is typically set to true for outside.

Test Plan: Incorporated these changes into a Mysql raft RPM
and used the DumpCertsInfo and LoadCertFiles on a timer thread
to refresh certificates from disk. New certicates are expected to
be planted through some external automation.

Reviewers: yashtc

Subscribers:

Tasks:

Tags: