### PR TITLE
add atomic header to compile and add vscode support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ README.html
 *.swp
 *.autosave
 *~
+compile_commands.json
 
 # IDE cruft
 .settings/
@@ -44,6 +45,7 @@ nbproject/
 .project
 .cproject
 .csettings/
+.vscode/
 
 # WWW dependencies which are not checked in directly
 www/tracing.*

--- a/src/kudu/consensus/consensus_peers.h
+++ b/src/kudu/consensus/consensus_peers.h
@@ -24,6 +24,7 @@
 #ifndef KUDU_CONSENSUS_CONSENSUS_PEERS_H_
 #define KUDU_CONSENSUS_CONSENSUS_PEERS_H_
 
+#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <ostream>


### PR DESCRIPTION
1. request_pending_ with type atomic is introduced in PR#134, code did not compile (P469004206) for me. Added atomic header to fix the problem.
2. Added vscode support in .gitignore file.