### PR TITLE
Adjust thread priority in kuduraft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ nbproject/
 .cproject
 .csettings/
 .vscode/
+.cache/*
+.clangd/*
 
 # WWW dependencies which are not checked in directly
 www/tracing.*

--- a/build-support/build-kuduraft.sh
+++ b/build-support/build-kuduraft.sh
@@ -12,7 +12,7 @@ KRB5_VERSION=1.18.2-12.el8.x86_64  # NOTE: only correct on CentOS 8!
 sudo dnf install -y autoconf automake cyrus-sasl-devel cyrus-sasl-gssapi \
   cyrus-sasl-plain flex gcc gcc-c++ gdb git java-1.8.0-openjdk \
   libtool make openssl-devel patch pkgconfig redhat-lsb-core rsync unzip \
-  vim-common which cmake doxygen \
+  vim-common which cmake doxygen libcap-devel \
   krb5-server-${KRB5_VERSION} krb5-workstation-${KRB5_VERSION}
 
 # DOWNLOAD AND BUILD THE THIRD-PARTY libraries

--- a/src/kudu/tserver/tablet_server.cc
+++ b/src/kudu/tserver/tablet_server.cc
@@ -48,6 +48,7 @@
 #endif
 #include "kudu/util/net/net_util.h"
 #include "kudu/util/status.h"
+#include "kudu/util/thread.h"
 
 using std::string;
 using kudu::fs::ErrorHandlerType;
@@ -211,6 +212,14 @@ std::string TabletServer::ConsensusServiceRpcQueueToString() const {
     return pool->RpcServiceQueueToString();
   }
   return "";
+}
+
+Status TabletServer::ShowKuduThreadStatus(std::vector<ThreadDescriptor>* threads) {
+  return GlobalShowThreadStatus(threads);
+}
+
+Status TabletServer::ChangeKuduThreadPriority(string pool, int priority) {
+  return GlobalChangeThreadPriority(pool, priority);
 }
 
 } // namespace tserver

--- a/src/kudu/tserver/tablet_server.h
+++ b/src/kudu/tserver/tablet_server.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "kudu/gutil/atomicops.h"
 #include "kudu/gutil/gscoped_ptr.h"
@@ -101,6 +102,22 @@ class TabletServer : public kserver::KuduServer {
    * Capture a snapshot of the RPC service queue in the server log file.
    */
   std::string ConsensusServiceRpcQueueToString() const;
+
+  // Show the status of all kudu threads, see ThreadDescriptor for what detailed
+  // information is included for each thread.
+  //
+  // @param threads Output parameters for all thread info.
+  // @return Status:OK if succeed
+  Status ShowKuduThreadStatus(std::vector<ThreadDescriptor>* threads);
+
+  // Change thread priority for a particular category, this not only changes the
+  // current threads belong to that category, but also future threads spawned in
+  // that category.
+  //
+  // @param category In the other words, thread pool name
+  // @param priority thread priority based on nice. Should be -20 to 19
+  // @return Status:OK if succeed
+  Status ChangeKuduThreadPriority(std::string pool, int priority);
 
  private:
   friend class TabletServerTestBase;

--- a/src/kudu/util/CMakeLists.txt
+++ b/src/kudu/util/CMakeLists.txt
@@ -233,7 +233,8 @@ set(UTIL_LIBS
   pb_util_proto
   protobuf
   version_info_proto
-  zlib)
+  zlib
+  cap)
 
 if(NOT APPLE)
   set(UTIL_LIBS


### PR DESCRIPTION
in tablet_server, two functions are introduced to allow query and change thread info from plugin
1. ShowKuduThreadStatus(std::vector<ThreadDescriptor>* threads) will put thread info in a output parameter
2. ChangeKuduThreadPriority(std::string pool, int priority) will change thread priority by thread pool, as well as modify default priority for each thread pool

Note
- This is safe as it compares the thread_id with all kudu managed threads
- CAP_SYS_NICE capability is acquired before changing the thread priority, and dropped after the action is done.
- libcap library is a dependency for this change.
- The way it adjust thread priority is consistent with mysqld.

Tested in a by introducing two sys_vars in the plugin, one used to query (printed to log for now, will change when working on plugin and mysqld change), the other used to change

Before (First column is pool, Last column is priority)
```
I1204 01:55:45.805929 3944027 VarsStatus.cpp:2970] acceptor pool|acceptor-3944256|3944256|0
I1204 01:55:45.805934 3944027 VarsStatus.cpp:2970] cache|fbm-evict-3944158|3944158|0
I1204 01:55:45.805938 3944027 VarsStatus.cpp:2970] reactor|rpc reactor-3944169|3944169|0
I1204 01:55:45.805941 3944027 VarsStatus.cpp:2970] reactor|rpc reactor-3944168|3944168|0
I1204 01:55:45.805961 3944027 VarsStatus.cpp:2970] reactor|rpc reactor-3944167|3944167|0
I1204 01:55:45.805967 3944027 VarsStatus.cpp:2970] reactor|rpc reactor-3944166|3944166|0
I1204 01:55:45.805971 3944027 VarsStatus.cpp:2970] reactor|rpc reactor-3944165|3944165|0
I1204 01:55:45.805976 3944027 VarsStatus.cpp:2970] reactor|rpc reactor-3944164|3944164|0
I1204 01:55:45.805980 3944027 VarsStatus.cpp:2970] reactor|rpc reactor-3944162|3944162|0
I1204 01:55:45.805984 3944027 VarsStatus.cpp:2970] reactor|rpc reactor-3944161|3944161|0
I1204 01:55:45.805987 3944027 VarsStatus.cpp:2970] reactor|rpc reactor-3944160|3944160|0
I1204 01:55:45.805991 3944027 VarsStatus.cpp:2970] reactor|rpc reactor-3944159|3944159|0
I1204 01:55:45.805995 3944027 VarsStatus.cpp:2970] server|excess-log-deleter-3944245|3944245|0
I1204 01:55:45.805999 3944027 VarsStatus.cpp:2970] server|result-tracker-3944244|3944244|0
I1204 01:55:45.806003 3944027 VarsStatus.cpp:2970] server|diag-logger-3944243|3944243|0
I1204 01:55:45.806007 3944027 VarsStatus.cpp:2970] service pool|rpc worker-3944255|3944255|0
I1204 01:55:45.806010 3944027 VarsStatus.cpp:2970] service pool|rpc worker-3944254|3944254|0
I1204 01:55:45.806015 3944027 VarsStatus.cpp:2970] service pool|rpc worker-3944253|3944253|0
I1204 01:55:45.806018 3944027 VarsStatus.cpp:2970] service pool|rpc worker-3944252|3944252|0
I1204 01:55:45.806023 3944027 VarsStatus.cpp:2970] service pool|rpc worker-3944251|3944251|0
I1204 01:55:45.806027 3944027 VarsStatus.cpp:2970] service pool|rpc worker-3944250|3944250|0
I1204 01:55:45.806031 3944027 VarsStatus.cpp:2970] service pool|rpc worker-3944249|3944249|0
I1204 01:55:45.806035 3944027 VarsStatus.cpp:2970] service pool|rpc worker-3944248|3944248|0
I1204 01:55:45.806041 3944027 VarsStatus.cpp:2970] service pool|rpc worker-3944247|3944247|0
I1204 01:55:45.806044 3944027 VarsStatus.cpp:2970] service pool|rpc worker-3944246|3944246|0
I1204 01:55:45.806047 3944027 VarsStatus.cpp:2970] thread pool|raft [worker]-3945611|3945611|0
```

Now change "thread pool" to 1 and "reactor" to -5 from sys_var in the plugin.
```
I1204 01:56:27.621516 3944027 VarsStatus.cpp:2970] acceptor pool|acceptor-3944256|3944256|0
I1204 01:56:27.621520 3944027 VarsStatus.cpp:2970] cache|fbm-evict-3944158|3944158|0
I1204 01:56:27.621524 3944027 VarsStatus.cpp:2970] reactor|rpc reactor-3944169|3944169|-5
I1204 01:56:27.621528 3944027 VarsStatus.cpp:2970] reactor|rpc reactor-3944168|3944168|-5
I1204 01:56:27.621532 3944027 VarsStatus.cpp:2970] reactor|rpc reactor-3944167|3944167|-5
I1204 01:56:27.621536 3944027 VarsStatus.cpp:2970] reactor|rpc reactor-3944166|3944166|-5
I1204 01:56:27.621539 3944027 VarsStatus.cpp:2970] reactor|rpc reactor-3944165|3944165|-5
I1204 01:56:27.621542 3944027 VarsStatus.cpp:2970] reactor|rpc reactor-3944164|3944164|-5
I1204 01:56:27.621546 3944027 VarsStatus.cpp:2970] reactor|rpc reactor-3944162|3944162|-5
I1204 01:56:27.621554 3944027 VarsStatus.cpp:2970] reactor|rpc reactor-3944161|3944161|-5
I1204 01:56:27.621557 3944027 VarsStatus.cpp:2970] reactor|rpc reactor-3944160|3944160|-5
I1204 01:56:27.621562 3944027 VarsStatus.cpp:2970] reactor|rpc reactor-3944159|3944159|-5
I1204 01:56:27.621565 3944027 VarsStatus.cpp:2970] server|excess-log-deleter-3944245|3944245|0
I1204 01:56:27.621569 3944027 VarsStatus.cpp:2970] server|result-tracker-3944244|3944244|0
I1204 01:56:27.621573 3944027 VarsStatus.cpp:2970] server|diag-logger-3944243|3944243|0
I1204 01:56:27.621577 3944027 VarsStatus.cpp:2970] service pool|rpc worker-3944255|3944255|0
I1204 01:56:27.621580 3944027 VarsStatus.cpp:2970] service pool|rpc worker-3944254|3944254|0
I1204 01:56:27.621584 3944027 VarsStatus.cpp:2970] service pool|rpc worker-3944253|3944253|0
I1204 01:56:27.621588 3944027 VarsStatus.cpp:2970] service pool|rpc worker-3944252|3944252|0
I1204 01:56:27.621592 3944027 VarsStatus.cpp:2970] service pool|rpc worker-3944251|3944251|0
I1204 01:56:27.621595 3944027 VarsStatus.cpp:2970] service pool|rpc worker-3944250|3944250|0
I1204 01:56:27.621599 3944027 VarsStatus.cpp:2970] service pool|rpc worker-3944249|3944249|0
I1204 01:56:27.621603 3944027 VarsStatus.cpp:2970] service pool|rpc worker-3944248|3944248|0
I1204 01:56:27.621608 3944027 VarsStatus.cpp:2970] service pool|rpc worker-3944247|3944247|0
I1204 01:56:27.621634 3944027 VarsStatus.cpp:2970] service pool|rpc worker-3944246|3944246|0
I1204 01:56:27.621637 3944027 VarsStatus.cpp:2970] thread pool|raft [worker]-3950745|3950745|1
```