### PR TITLE
[kuduraft] fix the accounting of failed_attempts_ counter

### DIFF
--- a/src/kudu/consensus/consensus_peers.cc
+++ b/src/kudu/consensus/consensus_peers.cc
@@ -508,7 +508,6 @@ void Peer::ProcessTabletCopyResponse() {
 #endif
 
 void Peer::ProcessResponseError(const Status& status) {
-  failed_attempts_++;
   string resp_err_info;
 
 #ifdef FB_DO_NOT_REMOVE
@@ -527,6 +526,9 @@ void Peer::ProcessResponseError(const Status& status) {
     return;
   }
 
+  // Increment failed attempts only when this is not an expected rejection by a
+  // peer due to file rotation
+  failed_attempts_++;
   KLOG_EVERY_N_SECS(WARNING, 300)
       << LogPrefixUnlocked() << "Couldn't send request to peer "
       << peer_pb_.permanent_uuid() << " for tablet " << tablet_id_ << "."


### PR DESCRIPTION
Summary:
When a peer responds with an error, the leader tracks such errors for
each individual peer through a counter 'failed_attempts_'. This counter
is incremented on every response that has an error status and unset
(reset to 0) when the leader gets a successful response from a given
peer. This was causing an issue due to a recent change on how heartbeats
are handled in combination with how file rotation works on a follower:

1. When a follower gets a AppendEntry() call, it rejects it if the logs
are not setup correctly yet (more frequent during file rotation in a
mysql instance). It uses "ConsensusErrorPB::CANNOT_PREPARE" as the
error code.
2. Such errors were incorrectly treated as failure of the peer, even
though it is a 'rejection-by-design' and the "failed_attempts_" counter
was incremented in "Peer::ProcessResponse()"
3. When the heartbeater tries to heartbeat to this peer (in a subsequent
cycle), it sees that this peer is failed and tries to send an empty
heartbeat request without reading anything from the log. This sets
"preceding_id" in the request field to be the queue's committed id. The
peer now rejects this empty status request with a LMP error since the
preceding-id does not match its log.
 4. This gets logged by the leader correctly into the error log. Thus
 most of the file rotation was causing a error line to be logged by the
 leader. In addition to the log file getting overwhelmed, this also makes
 causes an additional round trip on every file rotation causing small
 spikes in lags.

What is the fix?
Treat an expected rejection of an AppendEntry() call (based on status
message) as not being a failure of the peer.

Test Plan:
Test by building an rpm locally

Reviewers: arahut

Subscribers:

Tasks:

Tags: