### PR TITLE
Fix build from scratch

### DIFF
--- a/src/kudu/tools/CMakeLists.txt
+++ b/src/kudu/tools/CMakeLists.txt
@@ -56,6 +56,7 @@ target_link_libraries(kudu_tools_util
   log
   server_process
 #  tablet
+  tserver
   tool_proto
   ${KUDU_BASE_LIBS}
 )


### PR DESCRIPTION
Summary:

While trying to build this from scratch I saw the following error:

```
kuduraft/src/kudu/tools/tool_action_common.cc:62:10: fatal error: kudu/tserver/tserver_admin.proxy.h: No such file or directory
 #include "kudu/tserver/tserver_admin.proxy.h"   // IWYU pragma: keep
```

This is because at some point we included `tserver_admin_proxy` in
`tool_action_common.cc` but did not list `tserver` as a dependency for the
`kudu_tools_util` target. Include it here

Test Plan:

```
cd build
cmake ..
make
```

Make sure build succeeds.

Reviewers: anirbanr-fb, bhatvinay, mpercy, li-chi

Subscribers:

Tasks:

Tags:
Signed-off-by: Yichen <yichenshen@fb.com>