### PR TITLE
Add indication for cpp14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,8 @@ endif()
 # Compiler flags
 ############################################################
 
+set(CMAKE_CXX_STANDARD 14)
+
 # compiler flags that are common across debug/release builds
 #  -msse4.2: Enable sse4.2 compiler intrinsics.
 set(CXX_COMMON_FLAGS "-msse4.2")


### PR DESCRIPTION
Summary:

I see at least one warning about cpp14:

```
In file included from /home/yichenshen/kuduraft/src/kudu/util/thread.h:42,
                 from /home/yichenshen/kuduraft/src/kudu/util/rw_semaphore.h:32,
                 from /home/yichenshen/kuduraft/src/kudu/util/locks.h:33,
                 from /home/yichenshen/kuduraft/src/kudu/util/hdr_histogram.h:57,
                 from /home/yichenshen/kuduraft/src/kudu/util/metrics.h:246,
                 from /home/yichenshen/kuduraft/src/kudu/consensus/log_cache.h:35,
                 from /home/yichenshen/kuduraft/src/kudu/consensus/consensus_queue.h:39,
                 from /home/yichenshen/kuduraft/src/kudu/consensus/consensus_queue.cc:24:
/home/yichenshen/kuduraft/src/kudu/consensus/consensus_queue.cc: In member function ‘void kudu::consensus::PeerMessageQueue::NotifyObserversOfSuccessor(const string&)’:
/home/yichenshen/kuduraft/src/kudu/consensus/consensus_queue.cc:2105:16: warning: lambda capture initializers only available with -std=c++14 or -std=gnu++14
            [=, transfer_context = std::move(transfer_context_)] (
                ^~~~~~~~~~~~~~~~
/home/yichenshen/kuduraft/src/kudu/util/status.h:66:33: note: in definition of macro ‘KUDU_WARN_NOT_OK’
     const ::kudu::Status& _s = (to_call);              \
                                 ^~~~~~~
/home/yichenshen/kuduraft/src/kudu/consensus/consensus_queue.cc:2103:3: note: in expansion of macro ‘WARN_NOT_OK’
   WARN_NOT_OK(raft_pool_observers_token_->SubmitClosure(
   ^~~~~~~~~~~
```

Specify the platform requirement for CMake, but don't set it to required
so that non C++ 14 compilers still work (that example above likely
becomes a copy instead of a move).

Test Plan:

```
cd build
cmake ..
make
```

Make sure build completes and no CPP 14 warnings are generated.

Reviewers: anirbanr-fb, bhatvinay, mpercy, li-chi

Subscribers:

Tasks:

Tags:
Signed-off-by: Yichen <yichenshen@fb.com>