### PR TITLE
Add log line for sync vs async leader transfer

### DIFF
--- a/src/kudu/consensus/consensus_queue.cc
+++ b/src/kudu/consensus/consensus_queue.cc
@@ -1408,8 +1408,13 @@ void PeerMessageQueue::BeginWatchForSuccessor(
 
   if (successor_uuid && FLAGS_synchronous_transfer_leadership &&
       PeerTransferLeadershipImmediatelyUnlocked(successor_uuid.get())) {
+    LOG_WITH_PREFIX_UNLOCKED(INFO)
+      << "Leadership transfer to "<< successor_uuid << " started synchronously";
     return;
   }
+
+  LOG_WITH_PREFIX_UNLOCKED(INFO)
+    << "Leadership transfer: Watching for successor asynchronously";
 
   successor_watch_in_progress_ = true;
   designated_successor_uuid_ = successor_uuid;


### PR DESCRIPTION
Summary:

When transfering leadership there are 2 modes, a sync mode that'll start
the transfer immediately (wakes up target), or a async mode that'll wait
for the target to catch up before proceeding.

Add a log line so we can trace which happened.

Test Plan:

Logging change. Compile here for now. Quick to verify when integrated
with the plugin.

Reviewers: anirban-fb, vinaybhat

Subscribers:

Tasks:

Tags:
Signed-off-by: Yichen <yichenshen@fb.com>