### PR TITLE
Add a way to cancel TransferLeadership and ask for current state

### DIFF
--- a/src/kudu/consensus/consensus_queue.cc
+++ b/src/kudu/consensus/consensus_queue.cc
@@ -1405,6 +1405,7 @@ void PeerMessageQueue::BeginWatchForSuccessor(
   std::lock_guard<simple_spinlock> l(queue_lock_);
 
   transfer_context_ = std::move(transfer_context);
+  successor_watch_peer_notified_ = false;
 
   if (successor_uuid && FLAGS_synchronous_transfer_leadership &&
       PeerTransferLeadershipImmediatelyUnlocked(successor_uuid.get())) {
@@ -1421,6 +1422,11 @@ void PeerMessageQueue::EndWatchForSuccessor() {
   successor_watch_in_progress_ = false;
   transfer_context_ = boost::none;
   tl_filter_fn_ = nullptr;
+}
+
+bool PeerMessageQueue::WatchForSuccessorPeerNotified() {
+  std::lock_guard<simple_spinlock> l(queue_lock_);
+  return successor_watch_peer_notified_;
 }
 
 Status PeerMessageQueue::GetNextRoutingHopFromLeader(
@@ -2108,6 +2114,7 @@ void PeerMessageQueue::NotifyObserversOfSuccessor(const string& peer_uuid) {
              observer->NotifyPeerToStartElection(peer_uuid, std::move(transfer_context));
            })),
       LogPrefixUnlocked() + "Unable to notify RaftConsensus of available successor.");
+  successor_watch_peer_notified_ = true;
   transfer_context_ = boost::none;
 }
 

--- a/src/kudu/consensus/consensus_queue.h
+++ b/src/kudu/consensus/consensus_queue.h
@@ -402,6 +402,10 @@ class PeerMessageQueue {
       );
   void EndWatchForSuccessor();
 
+  // If the previous call to BeginWatchForSuccessor had resulted in a
+  // notification to a peer to start an election
+  bool WatchForSuccessorPeerNotified();
+
   // Get the UUID of the next routing hop from the local node.
   // Results not guaranteed to be valid if the current node is not the leader.
   Status GetNextRoutingHopFromLeader(const std::string& dest_uuid, std::string* next_hop) const;
@@ -692,6 +696,7 @@ class PeerMessageQueue {
   bool successor_watch_in_progress_;
   boost::optional<std::string> designated_successor_uuid_;
   boost::optional<TransferContext> transfer_context_;
+  bool successor_watch_peer_notified_ = false;
 
   std::function<bool(const kudu::consensus::RaftPeerPB&)> tl_filter_fn_;
   // We assume that we never have multiple threads racing to append to the queue.

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -327,6 +327,15 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
                             const boost::optional<ElectionContext>& prev_election_ctx,
                             LeaderStepDownResponsePB* resp);
 
+  // Attempts to cancel the leadership transfer. This stops any leadership
+  // transfers, then checks if we are past the point where we notified anyone to
+  // start a election. Returns OK if we have not (safe to assume
+  // TransferLeadership have not happened), and IllegalState if we have.
+  // This method cancels transfer initiated by the last TransferLeadership call
+  // and users are responsible for controling races to multiple calls of
+  // TransferLeadership to ensure the right one is cancelled.
+  Status CancelTransferLeadership();
+
   // Begin or end a leadership transfer period. During a transfer period, a
   // leader will not accept writes or config changes, but will continue updating
   // followers. If a leader transfer period is already in progress,


### PR DESCRIPTION
Summary:

Expose an API in raft_consensus to allow consumers to cancel a
leadership transfer.

The idea is that when an external party times out waiting for the no-op
event after TransferLeadership, it can call into kudu to cancel the
Transfer and also get some state on whether we can treat the transfer as
void (never happened).

Since we only allow a single transfer to happen at any time, there's
only one transfer that we can cancel. The cancellation acts on the last
requested transfer (ending transfer is idempotent and can be called even
if there's no transfer ongoing), and returns OK if the last requested
transfer has not requested an election on an external node.

The cancel API is intentionally designed to be called even after
raft_consensus thinks it's out of a transfer period. This is so that if
raft_consensus times out internally before a external caller times out,
we can still extract information about what happened in the last
transfer.

Test Plan:

Just make sure it builds here, test it out in fbcode.

Reviewers: anirban-fb, bhatvinay

Subscribers:

Tasks:

Tags:
Signed-off-by: Yichen <yichenshen@fb.com>