### PR TITLE
Fix chained election flag

### DIFF
--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -600,6 +600,10 @@ Status RaftConsensus::StartElection(ElectionMode mode, ElectionContext context) 
     context.current_leader_uuid_ = GetLeaderUuidUnlocked();
     if (context.source_uuid_.empty()) {
       context.source_uuid_ = context.current_leader_uuid_;
+    } else if (context.source_uuid_ != context.current_leader_uuid_) {
+      // If the origin of the election isn't the same as the leader we're
+      // promoting away from, it must mean that this election is part of a chain
+      context.is_chained_election_ = true;
     }
 
     RaftPeerPB::Role active_role = cmeta_->active_role();

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -170,7 +170,6 @@ struct ElectionContext {
       std::string source_uuid,
       bool is_origin_dead_promotion) :
     reason_(reason),
-    is_chained_election_(true),
     chained_start_time_(std::move(chained_start_time)),
     source_uuid_(std::move(source_uuid)),
     is_origin_dead_promotion_(is_origin_dead_promotion) {}
@@ -184,7 +183,7 @@ struct ElectionContext {
 
   // If this election is preceeded by other elections considered as a single
   // event. E.g. Multiple chained promotions
-  const bool is_chained_election_ = false;
+  bool is_chained_election_ = false;
 
   // The time the first election in the  started
   const Timepoint chained_start_time_;

--- a/src/kudu/tserver/consensus_service.cc
+++ b/src/kudu/tserver/consensus_service.cc
@@ -439,7 +439,7 @@ void ConsensusServiceImpl::RunLeaderElection(const RunLeaderElectionRequestPB* r
     s = consensus->StartElection(
         consensus::ElectionMode::ELECT_EVEN_IF_LEADER_IS_ALIVE,
         {consensus::ElectionReason::EXTERNAL_REQUEST,
-         std::move(request_start),
+         request_start,
          ctx.original_uuid(),
          ctx.is_origin_dead_promotion()});
   } else {


### PR DESCRIPTION
Summary:

Previously we assumed that anytime we get context when requested to
start an election, it's a chained election.

However, we wanted to pipe a context during a LMP to record downtime,
but that's a direct election (1 term bump).

Instead, check if the current leader is the same as the source in the
context (if present) to determine if this election is a chained election
triggered by a previous one (like leader => LBU => leader).

Test Plan:

Bring this into fbcode and check that the timestamps are right

Reviewers: anirban-fb, bhatvinay

Subscribers:

Tasks:

Tags:
Signed-off-by: Yichen <yichenshen@fb.com>