### PR TITLE
Make transfer context non-optional

### DIFF
--- a/src/kudu/consensus/consensus_queue.cc
+++ b/src/kudu/consensus/consensus_queue.cc
@@ -1401,7 +1401,7 @@ void PeerMessageQueue::AdvanceMajorityReplicatedWatermarkFlexiRaft(
 void PeerMessageQueue::BeginWatchForSuccessor(
     const boost::optional<string>& successor_uuid,
     const std::function<bool(const kudu::consensus::RaftPeerPB&)>& filter_fn,
-    boost::optional<PeerMessageQueue::TransferContext> transfer_context) {
+    PeerMessageQueue::TransferContext transfer_context) {
   std::lock_guard<simple_spinlock> l(queue_lock_);
 
   transfer_context_ = std::move(transfer_context);
@@ -2115,7 +2115,7 @@ void PeerMessageQueue::NotifyObserversOfSuccessor(const string& peer_uuid) {
       Bind(&PeerMessageQueue::NotifyObserversTask, Unretained(this),
            [=, transfer_context = std::move(transfer_context_)] (
              PeerMessageQueueObserver* observer
-           ) {
+           ) mutable {
              observer->NotifyPeerToStartElection(peer_uuid, std::move(transfer_context));
            })),
       LogPrefixUnlocked() + "Unable to notify RaftConsensus of available successor.");

--- a/src/kudu/consensus/consensus_queue.h
+++ b/src/kudu/consensus/consensus_queue.h
@@ -398,8 +398,7 @@ class PeerMessageQueue {
   void BeginWatchForSuccessor(
       const boost::optional<std::string>& successor_uuid,
       const std::function<bool(const kudu::consensus::RaftPeerPB&)>& filter_fn,
-      boost::optional<TransferContext> transfer_context = boost::none
-      );
+      TransferContext transfer_context);
   void EndWatchForSuccessor();
 
   // If the previous call to BeginWatchForSuccessor had resulted in a

--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -774,7 +774,7 @@ Status RaftConsensus::StepDown(LeaderStepDownResponsePB* resp) {
 
 Status RaftConsensus::TransferLeadership(const boost::optional<string>& new_leader_uuid,
     const std::function<bool(const kudu::consensus::RaftPeerPB&)>& filter_fn,
-    const boost::optional<ElectionContext>& prev_election_ctx,
+    const ElectionContext& election_ctx,
     LeaderStepDownResponsePB* resp) {
   TRACE_EVENT0("consensus", "RaftConsensus::TransferLeadership");
   ThreadRestrictions::AssertWaitAllowed();
@@ -808,7 +808,8 @@ Status RaftConsensus::TransferLeadership(const boost::optional<string>& new_lead
       return Status::InvalidArgument(msg);
     }
   }
-  return BeginLeaderTransferPeriodUnlocked(new_leader_uuid, filter_fn, prev_election_ctx);
+  return BeginLeaderTransferPeriodUnlocked(
+    new_leader_uuid, filter_fn, election_ctx);
 }
 
 Status RaftConsensus::CancelTransferLeadership() {
@@ -828,7 +829,7 @@ Status RaftConsensus::CancelTransferLeadership() {
 Status RaftConsensus::BeginLeaderTransferPeriodUnlocked(
     const boost::optional<string>& successor_uuid,
     const std::function<bool(const kudu::consensus::RaftPeerPB&)>& filter_fn,
-    const boost::optional<ElectionContext>& prev_election_ctx
+    const ElectionContext& election_ctx
   ) {
   DCHECK(lock_.is_locked());
   if (leader_transfer_in_progress_.CompareAndSwap(false, true)) {
@@ -838,16 +839,9 @@ Status RaftConsensus::BeginLeaderTransferPeriodUnlocked(
   }
   leader_transfer_in_progress_.Store(true, kMemOrderAcquire);
 
-  boost::optional<PeerMessageQueue::TransferContext> transfer_context =
-    boost::none;
-
   queue_->BeginWatchForSuccessor(
-      successor_uuid,
-      filter_fn,
-      prev_election_ctx ?
-        boost::make_optional(prev_election_ctx->TransferContext()) :
-        boost::none
-  );
+      successor_uuid, filter_fn, election_ctx.TransferContext());
+
   transfer_period_timer_->Start();
   return Status::OK();
 }

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -324,7 +324,7 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   // Additional calls to this method during the transfer period prolong it.
   Status TransferLeadership(const boost::optional<std::string>& new_leader_uuid,
                             const std::function<bool(const kudu::consensus::RaftPeerPB&)>& filter_fn,
-                            const boost::optional<ElectionContext>& prev_election_ctx,
+                            const ElectionContext& election_ctx,
                             LeaderStepDownResponsePB* resp);
 
   // Attempts to cancel the leadership transfer. This stops any leadership
@@ -343,7 +343,7 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   Status BeginLeaderTransferPeriodUnlocked(
       const boost::optional<std::string>& successor_uuid,
       const std::function<bool(const kudu::consensus::RaftPeerPB&)>& filter_fn,
-      const boost::optional<ElectionContext>& prev_election_ctx);
+      const ElectionContext& election_ctx);
   void EndLeaderTransferPeriod();
 
   // Creates a new ConsensusRound, the entity that owns all the data


### PR DESCRIPTION
Summary:

Since we're using the context to store downtimes, we'll need it in both
the case where a LBU starts the promotion, as well as a typical LMP
where an external party starts it.

As such, we'll always have a ElectionContext, so clean this up to make
it compulsory and simpler.

Test Plan:

Make sure both kudu and fbcode plugin can build.

Reviewers: anirban-fb, bhatvinay, li-chi

Subscribers:

Tasks:

Tags:
Signed-off-by: Yichen <yichenshen@fb.com>