### PR TITLE
Record chained start time for dead promotions

### DIFF
--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -159,9 +159,9 @@ enum ElectionReason {
 struct ElectionContext {
   typedef const std::chrono::system_clock::time_point Timepoint;
 
-  ElectionContext(ElectionReason reason) :
+  ElectionContext(ElectionReason reason, Timepoint chained_start_time) :
     reason_(reason),
-    chained_start_time_(start_time_),
+    chained_start_time_(chained_start_time),
     is_origin_dead_promotion_(reason == ElectionReason::ELECTION_TIMEOUT_EXPIRED) {}
 
   ElectionContext(
@@ -170,7 +170,7 @@ struct ElectionContext {
       std::string source_uuid,
       bool is_origin_dead_promotion) :
     reason_(reason),
-    chained_start_time_(std::move(chained_start_time)),
+    chained_start_time_(chained_start_time),
     source_uuid_(std::move(source_uuid)),
     is_origin_dead_promotion_(is_origin_dead_promotion) {}
 
@@ -1153,6 +1153,7 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   Random rng_;
 
   std::shared_ptr<rpc::PeriodicTimer> failure_detector_;
+  MonoTime failure_detector_last_snoozed_;
 
   AtomicBool leader_transfer_in_progress_;
   boost::optional<std::string> designated_successor_uuid_;

--- a/src/kudu/consensus/raft_consensus_quorum-test.cc
+++ b/src/kudu/consensus/raft_consensus_quorum-test.cc
@@ -926,8 +926,10 @@ TEST_F(RaftConsensusQuorumTest, TestLeaderElectionWithQuiescedQuorum) {
     int64_t flush_count_before =
         new_leader->consensus_metadata_for_tests()->flush_count_for_tests();
     LOG(INFO) << "Running election for future leader with index " << (current_config_size - 1);
-    ASSERT_OK(new_leader->StartElection(ElectionMode::ELECT_EVEN_IF_LEADER_IS_ALIVE,
-                                        { ElectionReason::EXTERNAL_REQUEST }));
+    ASSERT_OK(new_leader->StartElection(
+        ElectionMode::ELECT_EVEN_IF_LEADER_IS_ALIVE,
+        {ElectionReason::EXTERNAL_REQUEST, std::chrono::system_clock::now()}));
+
     WaitUntilLeaderForTests(new_leader.get());
     LOG(INFO) << "Election won";
     int64_t flush_count_after =

--- a/src/kudu/tserver/consensus_service.cc
+++ b/src/kudu/tserver/consensus_service.cc
@@ -433,6 +433,7 @@ void ConsensusServiceImpl::RunLeaderElection(const RunLeaderElectionRequestPB* r
   Status s;
   if (req->has_election_context()) {
     const LeaderElectionContextPB& ctx = req->election_context();
+    // original_start_time in protobuf is nanoseconds since epoch
     std::chrono::system_clock::time_point request_start =
       std::chrono::system_clock::time_point(
           std::chrono::nanoseconds(ctx.original_start_time()));
@@ -445,7 +446,8 @@ void ConsensusServiceImpl::RunLeaderElection(const RunLeaderElectionRequestPB* r
   } else {
     s = consensus->StartElection(
         consensus::ElectionMode::ELECT_EVEN_IF_LEADER_IS_ALIVE,
-        {consensus::ElectionReason::EXTERNAL_REQUEST});
+        {consensus::ElectionReason::EXTERNAL_REQUEST,
+         std::chrono::system_clock::now()});
   }
 
   if (PREDICT_FALSE(!s.ok())) {

--- a/src/kudu/util/monotime.cc
+++ b/src/kudu/util/monotime.cc
@@ -228,6 +228,17 @@ void MonoTime::ToTimeSpec(struct timespec* ts) const {
   MonoDelta::NanosToTimeSpec(nanos_, ts);
 }
 
+std::chrono::system_clock::time_point MonoTime::ToTimePoint() const {
+  timespec ts;
+  ToTimeSpec(&ts);
+  std::chrono::nanoseconds duration =
+      std::chrono::seconds{ts.tv_sec} + std::chrono::nanoseconds{ts.tv_nsec};
+
+  return std::chrono::system_clock::time_point{
+      std::chrono::duration_cast<std::chrono::system_clock::duration>(
+          duration)};
+}
+
 bool MonoTime::Equals(const MonoTime& other) const {
   return nanos_ == other.nanos_;
 }

--- a/src/kudu/util/monotime.h
+++ b/src/kudu/util/monotime.h
@@ -21,6 +21,7 @@
 //       to be processed by a compiler lacking C++11 support.
 #include <stdint.h>
 
+#include <chrono>
 #include <string>
 
 #ifdef KUDU_HEADERS_NO_STUBS
@@ -217,6 +218,12 @@ class KUDU_EXPORT MonoTime {
   /// @param [out] ts
   ///   Placeholder for the result value.
   void ToTimeSpec(struct timespec* ts) const;
+
+  /// Represent this point in time as a timepoint in chronos:system_clock, with
+  /// input representation into system_clock with nanosecond accuracy.
+  ///
+  /// @return @c The system_clock timepoint
+  std::chrono::system_clock::time_point ToTimePoint() const;
 
   /// Check whether this object represents the same point in time as the other.
   ///


### PR DESCRIPTION
Summary:

We want metrics on how long the ring is unavailable for writes. To
estimate that for dead promotions, we take the point of 1 heartbeat
after the start point of the failure detector's start time.

This should be a good proxy for the time of the first heartbeat failure,
and the leader should have failed somewhere between the failure
detector's start time and this time.

Test Plan:

Test in fbcode

Reviewers:

Subscribers:

Tasks:

Tags:
Signed-off-by: Yichen <yichenshen@fb.com>