### PR TITLE
Always log metrics

### DIFF
--- a/src/kudu/server/diagnostics_log.cc
+++ b/src/kudu/server/diagnostics_log.cc
@@ -340,7 +340,7 @@ Status DiagnosticsLog::LogMetrics() {
   MetricJsonOptions opts;
   opts.include_raw_histograms = false;
 
-  opts.only_modified_in_or_after_epoch = metrics_epoch_;
+  opts.only_modified_in_or_after_epoch = 0;
 
   // We don't output any metrics which have never been incremented. Though
   // this seems redundant with the "only include changed metrics" above, it


### PR DESCRIPTION
Previous setting only log changing value. Observing metrics log file, only the first line has all columns. Following lines (in the same epoch) has lots of missing columns as the value does not change. Metrics like raft_term does not change frequently, so it is missing from second log line. 

This change benchmark epoch to 0 instead of current epoch, so all value is considered as changing.

Test:
build and canary to merlin. All log lines have the same columns, and previous missing ones (eg. raft_term) are there.
```
I0405 13:42:23.221825 metrics 1649191343221825 [{"type":"server","id":"kudu.tabletserver","metrics":[{"name":"in_progress_ops","value":0},{"name":"log_cache_size","value":579},{"name":"logical_clock_timestamp","value":0},{"name":"reactor_load_percent","total_count":5990,"min":0,"mean":0,"percentile_75":0,"percentile_95":0,"percentile_99":0,"percentile_99_9":0,"percentile_99_99":0,"max":0,"total_sum":0},{"name":"log_cache_msg_size","value":579},{"name":"rpc_incoming_queue_time","total_count":177,"min":36,"mean":78.3107,"percentile_75":77,"percentile_95":104,"percentile_99":220,"percentile_99_9":2308,"percentile_99_99":2308,"max":2309,"total_sum":13861},{"name":"reactor_active_latency_us","total_count":11830,"min":0,"mean":3.54954,"percentile_75":2,"percentile_95":8,"percentile_99":80,"percentile_99_9":133,"percentile_99_99":169,"max":269,"total_sum":41991},{"name":"block_cache_usage","value":0},{"name":"raft_term","value":6},{"name":"spinlock_contention_time","value":0},{"name":"ops_behind_leader","value":0},{"name":"log_cache_payload_size","value":15410},{"name":"data_dirs_failed","value":0},{"name":"data_dirs_full","value":0},{"name":"rpc_connections_accepted","value":2},{"name":"log_cache_num_ops","value":1},{"name":"majority_done_ops","value":0},{"name":"block_manager_blocks_open_writing","value":0},{"name":"handler_latency_kudu_consensus_ConsensusService_UpdateConsensus","total_count":177,"min":48,"mean":148.927,"percentile_75":105,"percentile_95":398,"percentile_99":984,"percentile_99_9":1584,"percentile_99_99":1584,"max":1588,"total_sum":26360},{"name":"failed_elections_since_stable_leader","value":0},{"name":"log_cache_compressed_payload_size","value":15410},{"name":"block_manager_blocks_open_reading","value":0},{"name":"time_since_last_leader_heartbeat","value":330}]}]
I0405 13:43:23.221929 metrics 1649191403221929 [{"type":"server","id":"kudu.tabletserver","metrics":[{"name":"in_progress_ops","value":0},{"name":"log_cache_size","value":579},{"name":"logical_clock_timestamp","value":0},{"name":"reactor_load_percent","total_count":6000,"min":0,"mean":0,"percentile_75":0,"percentile_95":0,"percentile_99":0,"percentile_99_9":0,"percentile_99_99":0,"max":0,"total_sum":0},{"name":"log_cache_msg_size","value":579},{"name":"rpc_incoming_queue_time","total_count":175,"min":33,"mean":59.2629,"percentile_75":69,"percentile_95":99,"percentile_99":211,"percentile_99_9":349,"percentile_99_99":349,"max":349,"total_sum":10371},{"name":"reactor_active_latency_us","total_count":11789,"min":0,"mean":3.23793,"percentile_75":1,"percentile_95":6,"percentile_99":77,"percentile_99_9":111,"percentile_99_99":192,"max":235,"total_sum":38172},{"name":"block_cache_usage","value":0},{"name":"raft_term","value":6},{"name":"spinlock_contention_time","value":0},{"name":"ops_behind_leader","value":0},{"name":"log_cache_payload_size","value":28786},{"name":"data_dirs_failed","value":0},{"name":"data_dirs_full","value":0},{"name":"rpc_connections_accepted","value":2},{"name":"log_cache_num_ops","value":1},{"name":"majority_done_ops","value":0},{"name":"block_manager_blocks_open_writing","value":0},{"name":"handler_latency_kudu_consensus_ConsensusService_UpdateConsensus","total_count":175,"min":47,"mean":126.303,"percentile_75":87,"percentile_95":348,"percentile_99":418,"percentile_99_9":1004,"percentile_99_99":1004,"max":1005,"total_sum":22103},{"name":"failed_elections_since_stable_leader","value":0},{"name":"log_cache_compressed_payload_size","value":28786},{"name":"block_manager_blocks_open_reading","value":0},{"name":"time_since_last_leader_heartbeat","value":312}]}]
I0405 13:44:23.222002 metrics 1649191463222002 [{"type":"server","id":"kudu.tabletserver","metrics":[{"name":"in_progress_ops","value":0},{"name":"log_cache_size","value":578},{"name":"logical_clock_timestamp","value":0},{"name":"reactor_load_percent","total_count":6000,"min":0,"mean":0,"percentile_75":0,"percentile_95":0,"percentile_99":0,"percentile_99_9":0,"percentile_99_99":0,"max":0,"total_sum":0},{"name":"log_cache_msg_size","value":578},{"name":"rpc_incoming_queue_time","total_count":171,"min":36,"mean":58.4269,"percentile_75":67,"percentile_95":101,"percentile_99":160,"percentile_99_9":311,"percentile_99_99":311,"max":311,"total_sum":9991},{"name":"reactor_active_latency_us","total_count":11853,"min":0,"mean":3.13262,"percentile_75":1,"percentile_95":5,"percentile_99":76,"percentile_99_9":114,"percentile_99_99":168,"max":196,"total_sum":37131},{"name":"block_cache_usage","value":0},{"name":"raft_term","value":6},{"name":"spinlock_contention_time","value":0},{"name":"ops_behind_leader","value":0},{"name":"log_cache_payload_size","value":42168},{"name":"data_dirs_failed","value":0},{"name":"data_dirs_full","value":0},{"name":"rpc_connections_accepted","value":2},{"name":"log_cache_num_ops","value":1},{"name":"majority_done_ops","value":0},{"name":"block_manager_blocks_open_writing","value":0},{"name":"handler_latency_kudu_consensus_ConsensusService_UpdateConsensus","total_count":171,"min":49,"mean":139.339,"percentile_75":90,"percentile_95":352,"percentile_99":412,"percentile_99_9":3152,"percentile_99_99":3152,"max":3164,"total_sum":23827},{"name":"failed_elections_since_stable_leader","value":0},{"name":"log_cache_compressed_payload_size","value":42168},{"name":"block_manager_blocks_open_reading","value":0},{"name":"time_since_last_leader_heartbeat","value":297}]}]

```