### PR TITLE
Clean up voting logs, and export to vote logger

### DIFF
--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -97,6 +97,7 @@ class PersistentVarsManager;
 class PendingRounds;
 struct ConsensusBootstrapInfo;
 struct ElectionResult;
+class VoteLoggerInterface;
 
 struct ConsensusOptions {
   std::string tablet_id;
@@ -1089,6 +1090,7 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   void SetTermAdvancementCallback(TermAdvancementCallback tacb);
   void SetNoOpReceivedCallback(NoOpReceivedCallback norcb);
   void SetLeaderDetectedCallback(LeaderDetectedCallback ldcb);
+  void SetVoteLogger(std::shared_ptr<VoteLoggerInterface> vote_logger);
 
   const ConsensusOptions options_;
 
@@ -1215,6 +1217,9 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
 
   // this is not expected to change after a create of Raft.
   bool disable_noop_;
+
+  // Vote logger for voting events
+  std::shared_ptr<VoteLoggerInterface> vote_logger_;
 
   // A flag to help us avoid taking a lock on the reactor thread if the object
   // is already in kShutdown state.

--- a/src/kudu/tserver/simple_tablet_manager.cc
+++ b/src/kudu/tserver/simple_tablet_manager.cc
@@ -482,6 +482,9 @@ Status TSTabletManager::SetupRaft() {
   if (server_->opts().disable_noop) {
     consensus_->DisableNoOpEntries();
   }
+  if (server_->opts().vote_logger) {
+    consensus_->SetVoteLogger(server_->opts().vote_logger);
+  }
 
   // set_state(INITIALIZED);
   // SetStatusMessage("Initialized. Waiting to start...");

--- a/src/kudu/tserver/tablet_server_options.h
+++ b/src/kudu/tserver/tablet_server_options.h
@@ -22,6 +22,7 @@
 
 #include "kudu/consensus/metadata.pb.h"
 #include "kudu/consensus/proxy_policy.h"
+#include "kudu/consensus/leader_election.h"
 #include "kudu/server/server_base_options.h"
 #include "kudu/util/net/net_util.h"
 
@@ -58,6 +59,8 @@ struct TabletServerOptions : public kudu::server::ServerBaseOptions {
   std::vector<KC::RaftPeerPB> bootstrap_tservers;
 
   std::shared_ptr<kudu::log::LogFactory> log_factory;
+
+  std::shared_ptr<kudu::consensus::VoteLoggerInterface> vote_logger;
 
   kudu::consensus::ConsensusRoundHandler *round_handler = nullptr;
 


### PR DESCRIPTION
Summary:
1. Clean up voting / election related logs. Moving duplicated ones to VLOG.
2. Add host:port to log statement for better readability
3. Add vote_logger.log() in three places (1) Election started, (2) Voting received, (3) Election decided.
4. Edit leader-election-test so that code can compile.

Test Plan:
Tested in D35510511