### PR TITLE
advanceEpoch in bootstrap case

### DIFF
--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -3870,6 +3870,9 @@ Status RaftConsensus::SetCurrentTermBootstrap(int64_t new_term) {
   }
   cmeta_->set_current_term(new_term);
   CHECK_OK(cmeta_->Flush());
+  if (vote_logger_) {
+    vote_logger_->advanceEpoch(new_term);
+  }
   return Status::OK();
 }
 


### PR DESCRIPTION
This would help the very first pre-election case, where current term is not bumped.

After this, all adcanceEpoch is done in kudu instead of plugin.