### PR TITLE
Bring in SSL socket optimization from upstream

### DIFF
--- a/src/kudu/security/tls_context.cc
+++ b/src/kudu/security/tls_context.cc
@@ -170,7 +170,9 @@ Status TlsContext::Init() {
   if (!ctx_) {
     return Status::RuntimeError("failed to create TLS context", GetOpenSSLErrors());
   }
-  SSL_CTX_set_mode(ctx_.get(), SSL_MODE_AUTO_RETRY | SSL_MODE_ENABLE_PARTIAL_WRITE);
+  SSL_CTX_set_mode(
+      ctx_.get(),
+      SSL_MODE_AUTO_RETRY | SSL_MODE_ENABLE_PARTIAL_WRITE | SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
 
   // Disable SSLv2 and SSLv3 which are vulnerable to various issues such as POODLE.
   // We support versions back to TLSv1.0 since OpenSSL on RHEL 6.4 and earlier does not

--- a/src/kudu/security/tls_socket.cc
+++ b/src/kudu/security/tls_socket.cc
@@ -20,6 +20,7 @@
 #include <sys/uio.h>
 
 #include <cerrno>
+#include <cstddef>
 #include <string>
 #include <utility>
 
@@ -80,9 +81,62 @@ Status TlsSocket::Write(const uint8_t *buf, int32_t amt, int32_t *nwritten) {
 Status TlsSocket::Writev(const struct ::iovec *iov, int iov_len, int64_t *nwritten) {
   SCOPED_OPENSSL_NO_PENDING_ERRORS;
   CHECK(ssl_);
+
+  // Since OpenSSL doesn't support any kind of writev() call itself, this function
+  // sets TCP_CORK and then calls Write() for each of the buffers in the iovec,
+  // then unsets TCP_CORK. This causes the Linux kernel to buffer up the packets
+  // while corked and then send a minimal number of packets upon uncorking, whereas
+  // otherwise it would have sent at least packet per Write call. This is beneficial
+  // since it avoids generating lots of small packets, each of which has overhead in
+  // the network stack, etc.
+  //
+  // The downside, though, is that we need to make (iov_len + 2) system calls, each
+  // of which has some significant overhead (even moreso after spectre/meltdown
+  // mitigations were enabled). This can take significant CPU in the reactor thread,
+  // especially when the underlying buffers are small.
+  //
+  // To mitigate this, we handle a common case where the iovec has a few buffers,
+  // but the total iovec length is actually short. This is the case in many types
+  // of RPC requests/responses. In this case, it's cheaper to copy all of the buffers
+  // into a socket-local buffer 'buf_' and do a single Write call, vs doing the
+  // emulated Writev approach described above.
+  if (iov_len > 1) {
+    size_t total_size = 0;
+    for (int i = 0; i < iov_len; i++) {
+      total_size += iov[i].iov_len;
+    }
+    // Assume we can copy about 8 bytes per cycle, and a syscall takes about 1300 cycles,
+    // based on some quick benchmarking of 'setsockopt' on a GCP Sky Lake VM.
+    //
+    // cycles for memcpy and one write = total_size / 8 + syscall
+    // cycles for cork, N writes, uncork = syscall * (2 + iov_len)
+    //
+    // Solve the inequality to find where memcpy is faster:
+    // total_size / 8 + syscall < syscall * (2 + iov_len)
+    // total_size / 8 < syscall * (1 + iov_len)
+    // total_size < 8 * syscall * (1 + iov_len)
+    size_t max_copy_size = 8 * 1300 * (1 + iov_len);
+    if (total_size <= max_copy_size) {
+      buf_.clear();
+      buf_.reserve(total_size);
+      for (int i = 0; i < iov_len; i++) {
+        buf_.append(iov[i].iov_base, iov[i].iov_len);
+      }
+      // TODO(todd) Write()'s 'nwritten' parameter is int32_t* instead of int64_t*
+      // so we need this temporary. We should change Write() to use size_t as well.
+      int32_t n = 0;
+      Status s = Write(buf_.data(), buf_.size(), &n);
+      *nwritten = n;
+      return s;
+    }
+  }
+
   *nwritten = 0;
   // Allows packets to be aggresively be accumulated before sending.
-  RETURN_NOT_OK(SetTcpCork(1));
+  bool do_cork = iov_len > 1;
+  if (do_cork) {
+    RETURN_NOT_OK(SetTcpCork(1));
+  }
   Status write_status = Status::OK();
   for (int i = 0; i < iov_len; ++i) {
     int32_t frame_size = iov[i].iov_len;
@@ -95,7 +149,10 @@ Status TlsSocket::Writev(const struct ::iovec *iov, int iov_len, int64_t *nwritt
     *nwritten += bytes_written;
     if (bytes_written < frame_size) break;
   }
-  RETURN_NOT_OK(SetTcpCork(0));
+
+  if (do_cork) {
+    RETURN_NOT_OK(SetTcpCork(0));
+  }
   // If we did manage to write something, but not everything, due to a temporary socket
   // error, then we should still return an OK status indicating a successful _partial_
   // write.

--- a/src/kudu/security/tls_socket.h
+++ b/src/kudu/security/tls_socket.h
@@ -22,6 +22,7 @@
 
 #include "kudu/gutil/port.h"
 #include "kudu/security/openssl_util.h" // IWYU pragma: keep
+#include "kudu/util/faststring.h"
 #include "kudu/util/net/socket.h"
 #include "kudu/util/status.h"
 
@@ -54,6 +55,9 @@ class TlsSocket : public Socket {
 
   // Owned SSL handle.
   c_unique_ptr<SSL> ssl_;
+
+  // Socket-local buffer used by Writev().
+  faststring buf_;
 };
 
 } // namespace security


### PR DESCRIPTION
Summary:

In
https://github.com/apache/kudu/commit/5c104fe51ad7d56106446c6b32dde48dfee2cc0c,
an optimization to manually buffer small packets is introduced. Bring
that into kuduraft here.

Test Plan:

Sync with fbcode and test it there

Reviewers:

Subscribers:

Tasks:

Tags:
Signed-off-by: Yichen <yichenshen@fb.com>