### PR TITLE
Add functions to define values of SO_SNDBUF and SO_RCVBUF

### DIFF
--- a/src/kudu/rpc/acceptor_pool.cc
+++ b/src/kudu/rpc/acceptor_pool.cc
@@ -159,6 +159,9 @@ void AcceptorPool::RunThread() {
       continue;
     }
     s = new_sock.SetNoDelay(true);
+    if (s.ok() && messenger_->get_receive_buffer() > 0) {
+      s = new_sock.SetReceiveBuf(messenger_->get_receive_buffer());
+    }
     if (!s.ok()) {
       KLOG_EVERY_N_SECS(WARNING, 1) << "Acceptor with remote = " << remote.ToString()
           << " failed to set TCP_NODELAY on a newly accepted socket: "

--- a/src/kudu/rpc/messenger.h
+++ b/src/kudu/rpc/messenger.h
@@ -166,6 +166,14 @@ class MessengerBuilder {
   // Configure the messenger to set the SO_REUSEPORT socket option.
   MessengerBuilder& set_reuseport();
 
+  // Configure the messanger to set the SO_SNDBUF socket option for outbound sockets.
+  // 0 turns off the socket option. Values below kMinTcpBuf are treated as 0.
+  MessengerBuilder& set_send_buf(int send_buf);
+
+  // Configure the messanger to set the SO_RCVBUF socket option for inbound sockets.
+  // 0 turns off the socket option. Values below kMinTcpBuf are treated as 0.
+  MessengerBuilder& set_receive_buf(int receive_buf);
+
   Status Build(std::shared_ptr<Messenger> *msgr);
 
  private:
@@ -189,6 +197,8 @@ class MessengerBuilder {
   std::string keytab_file_;
   bool enable_inbound_tls_;
   bool reuseport_;
+  int send_buf_;
+  int receive_buf_;
 };
 
 // A Messenger is a container for the reactor threads which run event loops
@@ -324,6 +334,18 @@ class Messenger {
 
   const scoped_refptr<RpcService> rpc_service(const std::string& service_name) const;
 
+  int get_send_buffer() const{
+    return send_buf_;
+  }
+
+  void set_send_buffer(int send_buf);
+
+  int get_receive_buffer() const{
+    return receive_buf_;
+  }
+
+  void set_receive_buffer(int receive_buf);
+
  private:
   FRIEND_TEST(TestRpc, TestConnectionKeepalive);
   FRIEND_TEST(TestRpc, TestConnectionAlwaysKeepalive);
@@ -407,6 +429,13 @@ class Messenger {
 
   // Whether to set SO_REUSEPORT on the listening sockets.
   bool reuseport_;
+
+  // The value to set for SO_SNDBUF, the size of the tcp send buffer for outbound
+  // sockets. 0 or negative values will skip setting the option.
+  int send_buf_;
+  // The value to set for SO_RCVBUF, the size of the tcp receive buffer for
+  // inbound sockets. 0 or negative values will skip setting the option.
+  int receive_buf_;
 
   // The ownership of the Messenger object is somewhat subtle. The pointer graph
   // looks like this:

--- a/src/kudu/rpc/reactor.h
+++ b/src/kudu/rpc/reactor.h
@@ -255,7 +255,8 @@ class ReactorThread {
   void ScanIdleConnections();
 
   // Create a new client socket (non-blocking, NODELAY)
-  static Status CreateClientSocket(Socket *sock);
+  // buf_size can be specified to set SO_RCVBUF. 0 to skip setting
+  static Status CreateClientSocket(Socket *sock, int buf_size = 0);
 
   // Initiate a new connection on the given socket.
   static Status StartConnect(Socket *sock, const Sockaddr &remote);

--- a/src/kudu/server/rpc_server.h
+++ b/src/kudu/server/rpc_server.h
@@ -54,6 +54,9 @@ struct RpcServerOptions {
   size_t service_queue_length;
   bool rpc_reuseport;
   uint32_t num_reactor_threads;
+
+  int send_buffer_size = 0;
+  int receive_buffer_size = 0;
 };
 
 class RpcServer {

--- a/src/kudu/server/server_base.cc
+++ b/src/kudu/server/server_base.cc
@@ -499,6 +499,9 @@ Status ServerBase::Init() {
     builder.set_num_reactors(options_.rpc_opts.num_reactor_threads);
   }
 
+  builder.set_send_buf(options_.rpc_opts.send_buffer_size);
+  builder.set_receive_buf(options_.rpc_opts.receive_buffer_size);
+
   RETURN_NOT_OK(builder.Build(&messenger_));
   rpc_server_->set_too_busy_hook(std::bind(
       &ServerBase::ServiceQueueOverflowed, this, std::placeholders::_1));

--- a/src/kudu/util/net/socket.h
+++ b/src/kudu/util/net/socket.h
@@ -88,6 +88,12 @@ class Socket {
   // Sets SO_REUSEPORT to 'flag'. Should be used prior to Bind().
   Status SetReusePort(bool flag);
 
+  // Sets SO_SNDBUF to 'send_buf'.
+  Status SetSendBuf(int send_buf);
+
+  // Sets SO_RCVBUF to 'receive_buf'.
+  Status SetReceiveBuf(int receive_buf);
+
   // Convenience method to invoke the common sequence:
   // 1) SetReuseAddr(true)
   // 2) Bind()
@@ -158,6 +164,9 @@ class Socket {
   Status Peek(uint8_t *buf, size_t amt, size_t *nread, const MonoTime& deadline);
 
  private:
+  // Called internally to set a socket buffer size
+  Status SetSockBuf(int opt, const char* optname, int buf_size);
+
   // Called internally from SetSend/RecvTimeout().
   Status SetTimeout(int opt, const char* optname, const MonoDelta& timeout);
 


### PR DESCRIPTION
Summary:

Add a way to set SO_SNDBUF and SO_RCVBUF when the messenger starts a new
socket.

This allows us to configure the TCP buffer sizes.

Test Plan:

Start up a Raft ring with options configured and inspect the socket buf
sizes with `ss -tmp`. Values shown should be twice of what we set here.

Also run an election to make sure the values are still correct.

Currently there's no way to reset these values on the fly, but running
an election forces reshuffling of sockets, so we can change the value,
run an election, then check with `ss -tmp` again.

Reviewers:

Subscribers:

Tasks:

Tags:
Signed-off-by: Yichen <yichenshen@fb.com>