### PR TITLE
Add a handle in the messenger that can reset all connections

### DIFF
--- a/src/kudu/rpc/messenger.cc
+++ b/src/kudu/rpc/messenger.cc
@@ -459,6 +459,12 @@ Status Messenger::DumpRunningRpcs(const DumpRunningRpcsRequestPB& req,
   return Status::OK();
 }
 
+void Messenger::QueueResetConnections() {
+  for (Reactor* reactor : reactors_) {
+    reactor->QueueResetConnections();
+  }
+}
+
 void Messenger::ScheduleOnReactor(const boost::function<void(const Status&)>& func,
                                   MonoDelta when) {
   DCHECK(!reactors_.empty());

--- a/src/kudu/rpc/messenger.h
+++ b/src/kudu/rpc/messenger.h
@@ -269,6 +269,9 @@ class Messenger {
   Status DumpRunningRpcs(const DumpRunningRpcsRequestPB& req,
                          DumpRunningRpcsResponsePB* resp);
 
+  // Enqueue a call to reset the connections on all reactors
+  void QueueResetConnections();
+
   // Run 'func' on a reactor thread after 'when' time elapses.
   //
   // The status argument conveys whether 'func' was run correctly (i.e.

--- a/src/kudu/rpc/reactor.cc
+++ b/src/kudu/rpc/reactor.cc
@@ -342,6 +342,20 @@ void ReactorThread::RegisterConnection(scoped_refptr<Connection> conn) {
   server_conns_.emplace_back(std::move(conn));
 }
 
+void ReactorThread::ResetAllConnections() {
+    DCHECK(IsCurrentThread());
+    for (const scoped_refptr<Connection> &conn : server_conns_) {
+        conn->Shutdown(
+                Status::Aborted("Shutting down server connection by request"));
+    }
+    server_conns_.clear();
+
+    for (const auto &conn_entry : client_conns_) {
+        Connection *conn = conn_entry.second.get();
+        conn->set_scheduled_for_shutdown();
+    }
+}
+
 void ReactorThread::AssignOutboundCall(shared_ptr<OutboundCall> call) {
   DCHECK(IsCurrentThread());
 
@@ -901,6 +915,24 @@ class CancellationTask : public ReactorTask {
 
 void Reactor::QueueCancellation(const shared_ptr<OutboundCall>& call) {
   ScheduleReactorTask(new CancellationTask(call));
+}
+
+class ResetConnectionsTask : public ReactorTask {
+  public:
+    explicit ResetConnectionsTask() {}
+
+    void Run(ReactorThread* reactor) override {
+      reactor->ResetAllConnections();
+      delete this;
+    }
+
+    void Abort(const Status& /*status*/) override {
+      delete this;
+    }
+};
+
+void Reactor::QueueResetConnections() {
+    ScheduleReactorTask(new ResetConnectionsTask());
 }
 
 void Reactor::ScheduleReactorTask(ReactorTask *task) {

--- a/src/kudu/rpc/reactor.h
+++ b/src/kudu/rpc/reactor.h
@@ -206,6 +206,7 @@ class ReactorThread {
  private:
   friend class AssignOutboundCallTask;
   friend class CancellationTask;
+  friend class ResetConnectionsTask;
   friend class RegisterConnectionTask;
   friend class DelayedTask;
 
@@ -273,6 +274,9 @@ class ReactorThread {
 
   // Register a new connection.
   void RegisterConnection(scoped_refptr<Connection> conn);
+
+  // Manually destroy all connections so they can be recreated.
+  void ResetAllConnections();
 
   // Actually perform shutdown of the thread, tearing down any connections,
   // etc. This is called from within the thread.
@@ -382,6 +386,9 @@ class Reactor {
 
   // Queue a new reactor task to cancel an outbound call.
   void QueueCancellation(const std::shared_ptr<OutboundCall> &call);
+
+  // Queues a task to reset this reactor's connections
+  void QueueResetConnections();
 
   // Schedule the given task's Run() method to be called on the
   // reactor thread.


### PR DESCRIPTION
Summary:

This is intended to be called manually via an external API. It lets us
reset all connections so the any new connection/socket settings can be
applied when they're created again.

Test Plan:

Build in fbcode with a handle to trigger this, upload to staging, and
run it on both followers and leaders. Give it a while then check the
socket FDs to make sure they're changed. There shouldn't be any
disruptions to the ring other than that.

Reviewers:

Subscribers:

Tasks:

Tags:
Signed-off-by: Yichen <yichenshen@fb.com>