### PR TITLE
Bring in epoll optimization from upstream

### DIFF
--- a/src/kudu/rpc/connection.h
+++ b/src/kudu/rpc/connection.h
@@ -173,6 +173,26 @@ class Connection : public RefCountedThreadSafe<Connection> {
   // libev callback when we may write to the socket.
   void WriteHandler(ev::io &watcher, int revents);
 
+  enum ProcessOutboundTransfersResult {
+    // All of the transfers in the queue have been sent successfully.
+    // The queue is now empty.
+    kNoMoreToSend,
+    // Not all transfers were able to be sent. The caller should
+    // ensure that write_io_ is enabled in order to continue attempting
+    // to send transfers.
+    kMoreToSend,
+    // An error occurred trying to write to the connection, and the
+    // connection was destroyed. NOTE: 'this' may be deleted if this
+    // value is returned.
+    kConnectionDestroyed
+  };
+
+  // Process any pending outbound transfers in outbound_transfers_.
+  // Result indicates the state of the connection following the attempt.
+  //
+  // NOTE: This may invoke DestroyConnection() on 'this'.
+  ProcessOutboundTransfersResult ProcessOutboundTransfers();
+
   // Safe to be called from other threads.
   std::string ToString() const;
 

--- a/src/kudu/rpc/rpc-test.cc
+++ b/src/kudu/rpc/rpc-test.cc
@@ -28,6 +28,7 @@
 #include <string>
 #include <unistd.h>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <boost/bind.hpp>
@@ -533,11 +534,17 @@ TEST_P(TestRpc, TestClientConnectionMetrics) {
   add_req.set_x(rand());
   add_req.set_y(rand());
   AddResponsePB add_resp;
+  string big_string(8 * 1024 * 1024, 'a');
 
   vector<unique_ptr<RpcController>> controllers;
   CountDownLatch latch(n_calls);
   for (int i = 0; i < n_calls; i++) {
-    controllers.emplace_back(new RpcController());
+    unique_ptr<RpcController> rpc(new RpcController());
+    // Attach a big sidecar so that we are less likely to be able to send the
+    // whole RPC in a single write() call without queueing it.
+    int junk;
+    CHECK_OK(rpc->AddOutboundSidecar(RpcSidecar::FromSlice(big_string), &junk));
+    controllers.emplace_back(std::move(rpc));
     p.AsyncRequest(GenericCalculatorService::kAddMethodName, add_req, &add_resp,
         controllers.back().get(), boost::bind(&CountDownLatch::CountDown, boost::ref(latch)));
   }


### PR DESCRIPTION
Summary:

Our benchmarks show a noticeable amount of CPU spent in epoll. I found https://github.com/apache/kudu/commit/57a4ea30931dc140c3cff25623cd0bd664122321 from upstream which aims to reduce some unnecessary epoll calls so this PR just copies that over.

Test Plan:

Tried it out in fbcode. Based on strace I was seeing about 3.2k/s epolls before this patch, after it looks like it around 2.7k-2.9k/s

Reviewers:

Subscribers:

Tasks:

Tags:
Signed-off-by: Yichen <yichenshen@fb.com>