### PR TITLE
Various fixes in preparation for fbcode move

### DIFF
--- a/src/kudu/consensus/leader_election.cc
+++ b/src/kudu/consensus/leader_election.cc
@@ -260,7 +260,7 @@ FlexibleVoteCounter::FlexibleVoteCounter(
   // Computes voter distribution and uuid to region map.
   FetchTopologyInfo();
 
-  for (const std::pair<std::string, int>& regional_voter_count :
+  for (const std::pair<const std::string, int>& regional_voter_count :
       voter_distribution_) {
     // When instances are being removed from ring, the voter distribution
     // can have extra regions, but we have taken them out in
@@ -339,7 +339,7 @@ void FlexibleVoteCounter::FetchRegionalPrunedCounts(
     std::map<std::string, int32_t>* region_pruned_counts) const {
   CHECK(region_pruned_counts);
   region_pruned_counts->clear();
-  for (const std::pair<std::string, int64_t>& uuid_pruned_term_pair :
+  for (const std::pair<const std::string, int64_t>& uuid_pruned_term_pair :
       uuid_to_last_term_pruned_) {
     const std::string& uuid = uuid_pruned_term_pair.first;
     int64_t lpt = uuid_pruned_term_pair.second;
@@ -357,7 +357,7 @@ void FlexibleVoteCounter::FetchRegionalUnprunedCounts(
     std::map<std::string, int32_t>* region_unpruned_counts) const {
   CHECK(region_unpruned_counts);
   region_unpruned_counts->clear();
-  for (const std::pair<std::string, int64_t>& uuid_pruned_term_pair :
+  for (const std::pair<const std::string, int64_t>& uuid_pruned_term_pair :
       uuid_to_last_term_pruned_) {
     const std::string& uuid = uuid_pruned_term_pair.first;
     int64_t lpt = uuid_pruned_term_pair.second;
@@ -392,7 +392,7 @@ FlexibleVoteCounter::IsMajoritySatisfiedInRegions(
 
   for (const std::string& region : regions) {
     if (region.empty()) {
-      results.push_back(std::move(std::make_pair<>(false, false)));
+      results.push_back(std::make_pair<>(false, false));
       continue;
     }
 
@@ -426,8 +426,8 @@ FlexibleVoteCounter::IsMajoritySatisfiedInRegions(
                           << " Majority requirement: " << region_majority_size;
       quorum_satisfaction_possible = false;
     }
-    results.push_back(std::move(std::make_pair<>(
-        quorum_satisfied, quorum_satisfaction_possible)));
+    results.push_back(std::make_pair<>(
+                        quorum_satisfied, quorum_satisfaction_possible));
   }
   return results;
 }
@@ -518,7 +518,7 @@ FlexibleVoteCounter::IsPessimisticQuorumSatisfied() const {
 
   // Fetching all regions.
   std::set<std::string> regions;
-  for (const std::pair<std::string, int>& region_count_pair :
+  for (const std::pair<const std::string, int>& region_count_pair :
       voter_distribution_) {
     regions.insert(region_count_pair.first);
   }
@@ -528,7 +528,7 @@ FlexibleVoteCounter::IsPessimisticQuorumSatisfied() const {
 std::pair<bool, bool>
 FlexibleVoteCounter::IsMajoritySatisfiedInMajorityOfRegions() const {
   std::vector<std::string> regions_vector;
-  for (const std::pair<std::string, int32_t>& regional_count :
+  for (const std::pair<const std::string, int32_t>& regional_count :
       voter_distribution_) {
     regions_vector.push_back(regional_count.first);
   }
@@ -613,7 +613,7 @@ FlexibleVoteCounter::DoHistoricalVotesSatisfyMajorityInMajorityOfRegions(
   int32_t num_regions = 0;
   int32_t num_majority_satisfied = 0;
   int32_t num_majority_satisfaction_possible = 0;
-  for (const std::pair<std::string, int32_t>& regional_count :
+  for (const std::pair<const std::string, int32_t>& regional_count :
       voter_distribution_) {
     num_regions++;
     const std::string& region = regional_count.first;
@@ -641,7 +641,7 @@ void FlexibleVoteCounter::CrowdsourceLastKnownLeader(
     LastKnownLeaderPB* last_known_leader) const {
   CHECK(last_known_leader);
 
-  for (const std::pair<std::string, VoteInfo>& it : votes_) {
+  for (const std::pair<const std::string, VoteInfo>& it : votes_) {
     const VoteInfo& vote_info = it.second;
     const LastKnownLeaderPB& lkl = vote_info.last_known_leader;
 
@@ -697,7 +697,7 @@ void FlexibleVoteCounter::ConstructRegionWiseVoteCollation(
   vote_collation->clear();
   *min_term = std::numeric_limits<int64_t>::max();
 
-  for (const std::pair<std::string, VoteInfo>& it : votes_) {
+  for (const std::pair<const std::string, VoteInfo>& it : votes_) {
     const std::string& uuid = it.first;
     const VoteInfo& vote_info = it.second;
     const std::vector<PreviousVotePB>& pvh = vote_info.previous_vote_history;
@@ -857,7 +857,7 @@ PotentialNextLeadersResponse FlexibleVoteCounter::GetPotentialNextLeaders(
     FetchRegionalPrunedCounts(min_term, &region_pruned_counts);
 
     std::set<std::string> potential_leader_uuids;
-    for (const std::pair<UUIDTermPair, RegionToVoterSet>& collation_entry :
+    for (const std::pair<const UUIDTermPair, RegionToVoterSet>& collation_entry :
         vote_collation) {
       const std::string& uuid = collation_entry.first.first;
       int64_t vc_term = collation_entry.first.second;

--- a/src/kudu/consensus/log.cc
+++ b/src/kudu/consensus/log.cc
@@ -1270,7 +1270,7 @@ LogEntryBatch::~LogEntryBatch() {
     for (LogEntryPB& entry : *entry_batch_pb_->mutable_entry()) {
       // ReplicateMsg elements are owned by and must be freed by the caller
       // (e.g. the LogCache).
-      entry.release_replicate();
+      std::ignore = entry.release_replicate();
     }
   }
 }

--- a/src/kudu/consensus/log_cache.cc
+++ b/src/kudu/consensus/log_cache.cc
@@ -28,7 +28,6 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <google/protobuf/wire_format_lite.h>
-#include <google/protobuf/wire_format_lite_inl.h>
 
 #include "kudu/consensus/consensus.pb.h"
 #include "kudu/consensus/log.h"
@@ -272,7 +271,7 @@ Status LogCache::UncompressMsg(const ReplicateRefPtr& msg,
   rep_msg->set_op_type(msg->get()->op_type());
 
   WritePayloadPB* write_payload = rep_msg->mutable_write_payload();
-  write_payload->set_payload(std::move(buffer.ToString()));
+  write_payload->set_payload(buffer.ToString());
 
   uncompressed_msg->reset(rep_msg.release());
   return Status::OK();
@@ -331,7 +330,7 @@ Status LogCache::CompressMsg(const ReplicateMsg* msg,
   rep_msg->set_op_type(msg->op_type());
 
   WritePayloadPB* write_payload = rep_msg->mutable_write_payload();
-  write_payload->set_payload(std::move(buffer.ToString()));
+  write_payload->set_payload(buffer.ToString());
   write_payload->set_compression_codec(codec->type());
   write_payload->set_uncompressed_size(payload_str.size());
 
@@ -518,8 +517,8 @@ Status LogCache::AppendOperations(const vector<ReplicateRefPtr>& msgs,
         // Crash if uncompression failed
         CHECK_OK_PREPEND(status,
             Substitute("Uncompess failed when writing to log"));
-        uncompressed_msgs.push_back(std::move(
-              make_scoped_refptr_replicate(uncompressed_msg.release())));
+        uncompressed_msgs.push_back(
+            make_scoped_refptr_replicate(uncompressed_msg.release()));
       }
     }
 

--- a/src/kudu/gutil/stl_util.h
+++ b/src/kudu/gutil/stl_util.h
@@ -839,7 +839,7 @@ class STLCountingAllocator : public Alloc {
         bytes_used_(x.bytes_used()) {
   }
 
-  pointer allocate(size_type n, std::allocator<void>::const_pointer hint = 0) {
+  pointer allocate(size_type n, std::allocator_traits<std::allocator<void>>::const_pointer hint = 0) {
     assert(bytes_used_ != NULL);
     *bytes_used_ += n * sizeof(T);
     return Alloc::allocate(n, hint);

--- a/src/kudu/gutil/strings/escaping.cc
+++ b/src/kudu/gutil/strings/escaping.cc
@@ -866,7 +866,7 @@ int CalculateBase64EscapedLen(int input_len) {
 // filename-safe.
 // ----------------------------------------------------------------------
 
-int Base64UnescapeInternal(const char *src, int szsrc,
+int Base64UnescapeInternal(const unsigned char *src, int szsrc,
                            char *dest, int szdest,
                            const signed char* unbase64) {
   static const char kPad64 = '=';
@@ -1192,15 +1192,15 @@ static const signed char kUnWebSafeBase64[] = {
   -1,      -1,      -1,      -1,      -1,      -1,      -1,      -1
 };
 
-int Base64Unescape(const char *src, int szsrc, char *dest, int szdest) {
+int Base64Unescape(const unsigned char *src, int szsrc, char *dest, int szdest) {
   return Base64UnescapeInternal(src, szsrc, dest, szdest, kUnBase64);
 }
 
-int WebSafeBase64Unescape(const char *src, int szsrc, char *dest, int szdest) {
+int WebSafeBase64Unescape(const unsigned char *src, int szsrc, char *dest, int szdest) {
   return Base64UnescapeInternal(src, szsrc, dest, szdest, kUnWebSafeBase64);
 }
 
-static bool Base64UnescapeInternal(const char* src, int slen, string* dest,
+static bool Base64UnescapeInternal(const unsigned char* src, int slen, string* dest,
                                    const signed char* unbase64) {
   // Determine the size of the output string.  Base64 encodes every 3 bytes into
   // 4 characters.  any leftover chars are added directly for good measure.
@@ -1226,11 +1226,11 @@ static bool Base64UnescapeInternal(const char* src, int slen, string* dest,
   return true;
 }
 
-bool Base64Unescape(const char *src, int slen, string* dest) {
+bool Base64Unescape(const unsigned char *src, int slen, string* dest) {
   return Base64UnescapeInternal(src, slen, dest, kUnBase64);
 }
 
-bool WebSafeBase64Unescape(const char *src, int slen, string* dest) {
+bool WebSafeBase64Unescape(const unsigned char *src, int slen, string* dest) {
   return Base64UnescapeInternal(src, slen, dest, kUnWebSafeBase64);
 }
 
@@ -1376,7 +1376,7 @@ static const int kBase32NumUnescapedBytes[] = {
 
 int Base32Unescape(const char* src, int slen, char* dest, int szdest) {
   int destidx = 0;
-  char escaped_bytes[8];
+  unsigned char escaped_bytes[8];
   unsigned char unescaped_bytes[5];
   while (slen > 0) {
     // Collect the next 8 escaped bytes and convert to upper case.  If there
@@ -1579,13 +1579,13 @@ int CalculateBase32EscapedLen(size_t input_len) {
 // ----------------------------------------------------------------------
 
 
-void EightBase32DigitsToTenHexDigits(const char *in, char *out) {
+void EightBase32DigitsToTenHexDigits(const unsigned char *in, char *out) {
   unsigned char bytes[5];
   EightBase32DigitsToFiveBytes(in, bytes);
   b2a_hex(bytes, out, 5);
 }
 
-void EightBase32DigitsToFiveBytes(const char *in, unsigned char *bytes_out) {
+void EightBase32DigitsToFiveBytes(const unsigned char *in, unsigned char *bytes_out) {
   static const char Base32InverseAlphabet[] = {
     99,      99,      99,      99,      99,      99,      99,      99,
     99,      99,      99,      99,      99,      99,      99,      99,

--- a/src/kudu/gutil/strings/escaping.h
+++ b/src/kudu/gutil/strings/escaping.h
@@ -315,16 +315,16 @@ int QEncodingUnescape(const char* src, int slen, char* dest, int szdest);
 //    return false (with dest empty) if src contains invalid chars; for
 //    these versions src and dest must be different strings.
 // ----------------------------------------------------------------------
-int Base64Unescape(const char* src, int slen, char* dest, int szdest);
-bool Base64Unescape(const char* src, int slen, std::string* dest);
+int Base64Unescape(const unsigned char* src, int slen, char* dest, int szdest);
+bool Base64Unescape(const unsigned char* src, int slen, std::string* dest);
 inline bool Base64Unescape(const std::string& src, std::string* dest) {
-  return Base64Unescape(src.data(), src.size(), dest);
+  return Base64Unescape(reinterpret_cast<const unsigned char*>(src.data()), src.size(), dest);
 }
 
-int WebSafeBase64Unescape(const char* src, int slen, char* dest, int szdest);
-bool WebSafeBase64Unescape(const char* src, int slen, std::string* dest);
+int WebSafeBase64Unescape(const unsigned char* src, int slen, char* dest, int szdest);
+bool WebSafeBase64Unescape(const unsigned char* src, int slen, std::string* dest);
 inline bool WebSafeBase64Unescape(const std::string& src, std::string* dest) {
-  return WebSafeBase64Unescape(src.data(), src.size(), dest);
+  return WebSafeBase64Unescape(reinterpret_cast<const unsigned char*>(src.data()), src.size(), dest);
 }
 
 // Return the length to use for the output buffer given to the base64 escape
@@ -429,7 +429,7 @@ int CalculateBase32EscapedLen(size_t input_len);
 //   See RFC3548 at http://www.ietf.org/rfc/rfc3548.txt
 //   for details on base32.
 // ----------------------------------------------------------------------
-void EightBase32DigitsToTenHexDigits(const char* in, char* out);
+void EightBase32DigitsToTenHexDigits(const unsigned char* in, char* out);
 void TenHexDigitsToEightBase32Digits(const char* in, char* out);
 
 // ----------------------------------------------------------------------
@@ -448,7 +448,7 @@ void TenHexDigitsToEightBase32Digits(const char* in, char* out);
 //   Note that the Base64 functions above are different.  They deal with
 //   arbitrary lengths and we deal with single, whole base32 quanta.
 // ----------------------------------------------------------------------
-void EightBase32DigitsToFiveBytes(const char* in, unsigned char* bytes_out);
+void EightBase32DigitsToFiveBytes(const unsigned char* in, unsigned char* bytes_out);
 void FiveBytesToEightBase32Digits(const unsigned char* in_bytes, char* out);
 
 // ----------------------------------------------------------------------

--- a/src/kudu/rpc/serialization.cc
+++ b/src/kudu/rpc/serialization.cc
@@ -137,7 +137,11 @@ Status ParseMessage(const Slice& buf,
   // Protobuf enforces a 64MB total bytes limit on CodedInputStream by default.
   // Override this default with the actual size of the buffer to allow messages
   // larger than 64MB.
+#if GOOGLE_PROTOBUF_VERSION >= 3011000
+  in.SetTotalBytesLimit(buf.size());
+#else
   in.SetTotalBytesLimit(buf.size(), -1);
+#endif
   in.Skip(kMsgLengthPrefixLength);
 
   uint32_t header_len;

--- a/src/kudu/thrift/sasl_client_transport.cc
+++ b/src/kudu/thrift/sasl_client_transport.cc
@@ -117,7 +117,7 @@ SaslClientTransport::SaslClientTransport(string service_principal,
   ResetWriteBuf();
 }
 
-bool SaslClientTransport::isOpen() {
+bool SaslClientTransport::isOpen() const {
   return transport_->isOpen();
 }
 

--- a/src/kudu/thrift/sasl_client_transport.h
+++ b/src/kudu/thrift/sasl_client_transport.h
@@ -88,7 +88,7 @@ class SaslClientTransport
 
   ~SaslClientTransport() override = default;
 
-  bool isOpen() override;
+  bool isOpen() const override;
 
   bool peek() override;
 

--- a/src/kudu/util/debug-util.cc
+++ b/src/kudu/util/debug-util.cc
@@ -42,7 +42,9 @@
 #include <glog/logging.h>
 #include <glog/raw_logging.h>
 #ifdef __linux__
+#ifndef UNW_LOCAL_ONLY
 #define UNW_LOCAL_ONLY
+#endif
 #include <libunwind.h>
 #endif
 

--- a/src/kudu/util/debug/trace_event_impl.h
+++ b/src/kudu/util/debug/trace_event_impl.h
@@ -424,6 +424,8 @@ class BASE_EXPORT TraceLog {
   // on-demand.
   class EnabledStateObserver {
    public:
+    virtual ~EnabledStateObserver() {}
+
     // Called just after the tracing system becomes enabled, outside of the
     // |lock_|. TraceLog::IsEnabled() is true at this point.
     virtual void OnTraceLogEnabled() = 0;

--- a/src/kudu/util/jsonreader.cc
+++ b/src/kudu/util/jsonreader.cc
@@ -37,7 +37,10 @@ JsonReader::~JsonReader() {
 Status JsonReader::Init() {
   document_.Parse<0>(text_.c_str());
   if (document_.HasParseError()) {
-    return Status::Corruption("JSON text is corrupt", document_.GetParseError());
+    // TODO(yichenshen): Error msg removed for now for rapidjson forward compatiability.
+    // Use GetParseError_En when we have a newer rapidjson version
+    // return Status::Corruption("JSON text is corrupt", document_.GetParseError());
+    return Status::Corruption("JSON text is corrupt");
   }
   return Status::OK();
 }

--- a/src/kudu/util/jsonwriter.cc
+++ b/src/kudu/util/jsonwriter.cc
@@ -49,9 +49,11 @@ namespace kudu {
 // Since Squeasel exposes a stringstream as its interface, this is needed to avoid overcopying.
 class UTF8StringStreamBuffer {
  public:
+  using Ch = rapidjson::UTF8<>::Ch;
+
   explicit UTF8StringStreamBuffer(std::ostringstream* out);
   ~UTF8StringStreamBuffer();
-  void Put(rapidjson::UTF8<>::Ch c);
+  void Put(Ch c);
 
   void Flush();
 

--- a/src/kudu/util/memory/arena.h
+++ b/src/kudu/util/memory/arena.h
@@ -253,7 +253,7 @@ template<class T, bool THREADSAFE> class ArenaAllocator {
 
   ~ArenaAllocator() { }
 
-  pointer allocate(size_type n, std::allocator<void>::const_pointer /*hint*/ = 0) {
+  pointer allocate(size_type n, std::allocator_traits<std::allocator<void>>::const_pointer /*hint*/ = 0) {
     return reinterpret_cast<T*>(arena_->AllocateBytes(n * sizeof(T)));
   }
 

--- a/src/kudu/util/pb_util.cc
+++ b/src/kudu/util/pb_util.cc
@@ -365,7 +365,11 @@ Status ReadPBStartingAt(ReadableFileType* reader, int version,
   // integer overflow warnings, so that's what we'll use.
   ArrayInputStream ais(body.data(), body.size());
   CodedInputStream cis(&ais);
+#if GOOGLE_PROTOBUF_VERSION >= 3011000
+  cis.SetTotalBytesLimit(512 * 1024 * 1024);
+#else
   cis.SetTotalBytesLimit(512 * 1024 * 1024, -1);
+#endif
   if (PREDICT_FALSE(!msg->ParseFromCodedStream(&cis))) {
     return Status::IOError("Unable to parse PB from path", reader->filename());
   }


### PR DESCRIPTION
Summary:

In fbcode there will be a few changes:

 - C++ standard will be 20, some std apis are removed
 - Third party libraries will be following tp2 versions, which has some backward incompatibilities.
 - The build flags in this repo tells the compiler to ignore certain warnings, which in fbcode will become errors
 - ~Some third party APIs are simply incompatible both ways, so those are put behind a FBCODE_FIXES def flag~

I'll comment more on specific fixes on the code comments themselves.

Test Plan:

Most of these are refactors, but will test the whole batch together in
fbcode

Reviewers:

Subscribers:

Tasks:

Tags:
Signed-off-by: Yichen <yichenshen@fb.com>