### PR TITLE
Updated to set alpns in both client and server

### DIFF
--- a/src/kudu/security/tls_context.h
+++ b/src/kudu/security/tls_context.h
@@ -259,7 +259,8 @@ class TlsContext {
   bool enable_normal_tls_;
 
   // alpn protocols in wire format
-  std::vector<unsigned char> alpns_;
+  std::vector<unsigned char> server_alpns_;
+  bool client_alpns_are_set_{false};
 };
 
 } // namespace security


### PR DESCRIPTION
Summary:

Existing TlsContext::setSupportedAlpns() will set alpns once for the
same TLS context object either for client or the server. In use cases
where the mysqld is both client and server, the alpns are only set for
the server since the server calls setSupportedAlpns first and the client
does not have alpns set.

The updated code sets alpns for client and server sides independently.

Test Plan:

Built and updated mysql raft so file in the mysql server. Verified that
alpn was negotiated correctly.

Reviewers:

Subscribers:

Tasks:

Tags: