### PR TITLE
Counters for RPC mismatches

### DIFF
--- a/src/kudu/tserver/consensus_service.h
+++ b/src/kudu/tserver/consensus_service.h
@@ -130,6 +130,8 @@ class ConsensusServiceImpl : public consensus::ConsensusServiceIf {
  private:
   server::ServerBase* server_;
   TSTabletManager* tablet_manager_;
+
+  scoped_refptr<Counter> request_rpc_token_mismatches_;
 };
 
 } // namespace tserver

--- a/src/kudu/tserver/simple_tablet_manager.cc
+++ b/src/kudu/tserver/simple_tablet_manager.cc
@@ -407,7 +407,8 @@ Status TSTabletManager::Start(bool is_first_run) {
   gscoped_ptr<PeerProxyFactory> peer_proxy_factory;
   scoped_refptr<ITimeManager> time_manager;
 
-  peer_proxy_factory.reset(new RpcPeerProxyFactory(server_->messenger()));
+  peer_proxy_factory.reset(
+      new RpcPeerProxyFactory(server_->messenger(), server_->metric_entity()));
 
   if (server_->opts().enable_time_manager) {
     // THIS IS OBVIOUSLY NOT CORRECT.


### PR DESCRIPTION
This is meant to go on top of #162, so getting past #162 will make this much easier to review.

Mismatches will bump the counter even if we're not enforcing.

Proxies are a bit tricky, and currently they bump counters on both the
proxy and the origin. This is because at the consensus_peers layer we
don't differentiate between proxies and origins. I still think it's ok
because we are aiming to get the counter totally to 0. Any value above 1
is bad anyway.

I tested this in fbcode by querying the metrics server. I was able to verify that once I landed a bad rpc token the counters on both the leader and follower starts going up. 