### PR TITLE
[1/2] Allow changing peer quorum_id and allow changing use_quorum_id

### DIFF
--- a/src/kudu/consensus/metadata.proto
+++ b/src/kudu/consensus/metadata.proto
@@ -48,6 +48,9 @@ message RaftPeerAttrsPB {
 
   // The mysql/bls server id
   optional uint32 server_id = 6 [ default = 0 ];
+
+  // Define which quorum the peer belongs to in Flexiraft under use_quorum_id
+  optional string quorum_id = 7;
 }
 
 // Report on a replica's (peer's) health.
@@ -86,6 +89,11 @@ enum QuorumMode {
   SINGLE_REGION_DYNAMIC = 2;
 }
 
+enum QuorumType {
+  REGION = 0;
+  QUORUM_ID = 1;
+}
+
 // Analogue of CommitRulePredicate on the plugin.
 // Defines a single predicate in the static quorum modes.
 // The predicates are of the form:
@@ -101,6 +109,8 @@ message CommitRulePredicatePB {
 message CommitRulePB {
   required QuorumMode mode = 1;
   repeated CommitRulePredicatePB rule_predicates = 2;
+  // Use quorum_id instead of region for flexiraft quorum
+  optional QuorumType quorum_type = 3;
 }
 
 // Represents the arrangement of master and its slaves for a MySQL replica set.

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -491,6 +491,22 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   // Return the proxy topology.
   ProxyTopologyPB GetProxyTopology() const;
 
+  // On a live Raft Instance to use quorum_id instead of region for flexiraft
+  Status ChangeQuorumType(QuorumType type);
+
+  // Get QuorumType from committed config
+  QuorumType GetQuorumType() const;
+
+  // Update peer's quorum_id given uuid to quorum_id map. This is an atomic
+  // write, meaning that either all peers in map are updated or none gets
+  // updated.
+  //
+  // When force = false, reject update when use_quorum_id is true or one or more
+  // peers in active config does not exist in the map. Set force = true to
+  // bypass the check.
+  Status SetPeerQuorumIds(std::map<std::string, std::string> uuid2quorum_ids,
+                          bool force = false);
+
   // Only relevant for abstracted logs.
   // Callback the log abstraction's TruncateOpsAfter function
   // while holding Raft Consensus lock. This is to serialize


### PR DESCRIPTION
# Sub-region commit

When commit use_quorum_id is true, quorum is defined by quorum_id, where the MySQL instance and its two LBUs should have the same quorum_id. In peer attribute, each peer has the unchanged region property, plus the new quorum_id.  Commit watermark calculation and leader election calculation is based on quorum_id instead of region. 

## Changes in this PR
### Add two protobuf fields:
1) quorum_id
2) use_quorum_id

### And the functions to query and change them.
These two change functions are only supposed to use to convert existing raft replicasets to sub-region or navigate certain tricky situation. In common uses, the settings should be passed by tablet_server_option's TopologyConfigPB during raft enablement.

## Tests have done
1. Online changing two sys_vars
2. show raft status reflects the changes
3. Restart shows that changes are persistent

Details in diff test plan.

## Next PR
In the next PR, will change the actual consensus_queue and leader_election to support quorum_id for water mark calculation and vote count.