### PR TITLE
[2/2] Use quorum_id for leader election and flexiraft watermark

### DIFF
--- a/src/kudu/consensus/consensus_queue.cc
+++ b/src/kudu/consensus/consensus_queue.cc
@@ -42,6 +42,7 @@
 #include "kudu/common/timestamp.h"
 #include "kudu/consensus/consensus.pb.h"
 #include "kudu/consensus/log.h"
+#include "kudu/consensus/metadata.pb.h"
 #include "kudu/consensus/opid_util.h"
 #include "kudu/consensus/quorum_util.h"
 #include "kudu/consensus/routing.h"
@@ -1212,16 +1213,13 @@ int64_t PeerMessageQueue::ComputeNewWatermarkDynamicMode(int64_t* watermark) {
   CHECK(queue_state_.active_config->commit_rule().mode() ==
       QuorumMode::SINGLE_REGION_DYNAMIC);
 
-  // Double check that the local leader has the proper metadata.
-  CHECK(local_peer_pb_.has_attrs() && local_peer_pb_.attrs().has_region());
+  const std::string& leader_quorum = getQuorumIdUsingCommitRule(local_peer_pb_);
 
-  const std::string& leader_region = local_peer_pb_.attrs().region();
-
-  // Compute the watermarks in leader region. As an example, at the end of this
-  // loop, watermarks_in_leader_region might have entries (3, 7, 5) which
-  // indicates that the leader region has 3 peers that have responded to OpId
+  // Compute the watermarks in leader quorum. As an example, at the end of this
+  // loop, watermarks_in_leader_quorum might have entries (3, 7, 5) which
+  // indicates that the leader quorum has 3 peers that have responded to OpId
   // indexes 3, 7 and 5 respectively
-  std::vector<int64_t> watermarks_in_leader_region;
+  std::vector<int64_t> watermarks_in_leader_quorum;
   for (const PeersMap::value_type& peer : peers_map_) {
     // Only voter members are considered for advancing watermark
     if (peer.second->peer_pb.member_type() != RaftPeerPB::VOTER) {
@@ -1231,16 +1229,21 @@ int64_t PeerMessageQueue::ComputeNewWatermarkDynamicMode(int64_t* watermark) {
     // Refer to the comment in AdvanceQueueWatermark method for why only
     // successful last exchanges are considered.
     if (peer.second->last_exchange_status == PeerStatus::OK) {
-      const string& peer_region = peer.second->peer_pb.attrs().region();
-      if (peer_region == leader_region) {
-        watermarks_in_leader_region.push_back(
+      const string& peer_quorum_id = getQuorumIdUsingCommitRule(peer.second->peer_pb);
+      if (peer_quorum_id == leader_quorum) {
+        watermarks_in_leader_quorum.push_back(
             peer.second->last_received.index());
       }
     }
   }
 
+  std::map<std::string, int> voter_distribution;
+
+  // Compute total number of voters in each region.
+  GetVoterDistributionForQuorumId(*(queue_state_.active_config), &voter_distribution);
+
   int total_voters_from_voter_distribution =
-    FindOrDie(queue_state_.active_config->voter_distribution(), leader_region);
+    FindOrDie(voter_distribution, leader_quorum);
 
   // Compute number of voters in each region in the active config.
   // As voter distribution provided in topology config can lag,
@@ -1255,10 +1258,9 @@ int64_t PeerMessageQueue::ComputeNewWatermarkDynamicMode(int64_t* watermark) {
       continue;
     }
 
-    CHECK(peer_pb.has_permanent_uuid() && peer_pb.has_attrs() &&
-        peer_pb.attrs().has_region());
-    const std::string& peer_pb_region = peer_pb.attrs().region();
-    if (peer_pb_region != leader_region) {
+    CHECK(peer_pb.has_permanent_uuid());
+    const std::string& peer_pb_quorum_id = getQuorumIdUsingCommitRule(peer_pb);
+    if (peer_pb_quorum_id != leader_quorum) {
       // In dynamic mode, only the leader region matters
       continue;
     }
@@ -1283,24 +1285,24 @@ int64_t PeerMessageQueue::ComputeNewWatermarkDynamicMode(int64_t* watermark) {
   // Return without advancing the commit watermark, if majority in leader
   // region is not satisfied, ie. not enough number of replicas have responded
   // from that region.
-  if (watermarks_in_leader_region.size() < commit_req) {
+  if (watermarks_in_leader_quorum.size() < commit_req) {
     if (VLOG_IS_ON(3)) {
       VLOG_WITH_PREFIX_UNLOCKED(3)
           << "Watermarks size: "
-          << watermarks_in_leader_region.size()
+          << watermarks_in_leader_quorum.size()
           << ", Num peers required: " << commit_req
-          << ", Region: " << leader_region;
+          << ", Quorum: " << leader_quorum;
     }
     return *watermark;
   }
 
   // Sort the watermarks
   std::sort(
-      watermarks_in_leader_region.begin(), watermarks_in_leader_region.end());
+      watermarks_in_leader_quorum.begin(), watermarks_in_leader_quorum.end());
 
   int64_t old_watermark = *watermark;
-  *watermark = watermarks_in_leader_region[
-      watermarks_in_leader_region.size() - commit_req];
+  *watermark = watermarks_in_leader_quorum[
+      watermarks_in_leader_quorum.size() - commit_req];
   return old_watermark;
 }
 
@@ -1382,12 +1384,12 @@ void PeerMessageQueue::AdvanceMajorityReplicatedWatermarkFlexiRaft(
   int64_t old_watermark = -1;
   if (queue_state_.active_config->commit_rule().mode() ==
       QuorumMode::SINGLE_REGION_DYNAMIC) {
-    const std::string& leader_region = local_peer_pb_.attrs().region();
-    const std::string& peer_region = who_caused->peer_pb.attrs().region();
+    const std::string& leader_quorum = getQuorumIdUsingCommitRule(local_peer_pb_);
+    const std::string& peer_quorum = getQuorumIdUsingCommitRule(who_caused->peer_pb);
 
     // In SINGLE_REGION_DYNAMIC mode, only an ack from the leader region can
     // advance the watermark. Skip this expensive operation otherwise
-    if (leader_region == peer_region) {
+    if (leader_quorum == peer_quorum) {
       old_watermark = ComputeNewWatermarkDynamicMode(watermark);
     }
   } else {
@@ -2168,6 +2170,27 @@ string PeerMessageQueue::QueueState::ToString() const {
       committed_index, OpIdToString(last_appended), last_idx_appended_to_leader, current_term,
       majority_size_, state, (mode == LEADER ? "LEADER" : "NON_LEADER"),
       active_config ? ", active raft config: " + SecureShortDebugString(*active_config) : "");
+}
+
+std::string PeerMessageQueue::getQuorumIdUsingCommitRule(const RaftPeerPB& peer) {
+  return GetQuorumId(peer, queue_state_.active_config->commit_rule());
+}
+
+void PeerMessageQueue::UpdatePeerQuorumIdUnlocked(
+    const std::map<std::string, std::string>& quorum_id_map) {
+  // Update quorum_ids in peers_map
+  for (const PeersMap::value_type& entry : peers_map_) {
+    auto it = quorum_id_map.find(entry.first);
+    if (it != quorum_id_map.end()) {
+      entry.second->peer_pb.mutable_attrs()->set_quorum_id(it->second);
+    }
+  }
+
+  // Update local peer's quorum id
+  auto it = quorum_id_map.find(local_peer_pb_.permanent_uuid());
+  if (it != quorum_id_map.end()) {
+    local_peer_pb_.mutable_attrs()->set_quorum_id(it->second);
+  }
 }
 
 }  // namespace consensus

--- a/src/kudu/consensus/consensus_queue.h
+++ b/src/kudu/consensus/consensus_queue.h
@@ -438,6 +438,9 @@ class PeerMessageQueue {
     adjust_voter_distribution_ = val;
   }
 
+  // Update quorum id in peers_map
+  void UpdatePeerQuorumIdUnlocked(const std::map<std::string, std::string>& quorum_id_map);
+
  private:
   FRIEND_TEST(ConsensusQueueTest, TestQueueAdvancesCommittedIndex);
   FRIEND_TEST(ConsensusQueueTest, TestQueueMovesWatermarksBackward);
@@ -666,9 +669,9 @@ class PeerMessageQueue {
       int64_t* watermark, const OpId& replicated_before,
       const OpId& replicated_after, const TrackedPeer* who_caused);
 
-  // Fetches the data commit quorum as a mapping from region to count of
-  // votes required.
-  void GetDataCommitQuorum(std::map<std::string, int>*) const;
+  // return the region of peer or quorum_id of peer based on use_quorum_id
+  // in commit rule
+  std::string getQuorumIdUsingCommitRule(const RaftPeerPB& peer);
 
   std::vector<PeerMessageQueueObserver*> observers_;
 
@@ -676,7 +679,7 @@ class PeerMessageQueue {
   std::unique_ptr<ThreadPoolToken> raft_pool_observers_token_;
 
   // PB containing identifying information about the local peer.
-  const RaftPeerPB local_peer_pb_;
+  RaftPeerPB local_peer_pb_;
 
   std::shared_ptr<RoutingTableContainer> routing_table_container_;
 

--- a/src/kudu/consensus/leader_election.h
+++ b/src/kudu/consensus/leader_election.h
@@ -193,7 +193,7 @@ class FlexibleVoteCounter : public VoteCounter {
   // Fetch the region corresponding to server UUID. Returns an empty string
   // if UUID is not found. This could happen during a configuration change,
   // if a server was removed from the configuration.
-  std::string DetermineRegionForUUID(const std::string& uuid) const;
+  std::string DetermineQuorumIdForUUID(const std::string& uuid) const;
 
   // Given a set of regions, returns a pair of booleans for each region
   // representing:
@@ -360,8 +360,8 @@ class FlexibleVoteCounter : public VoteCounter {
   // Config at the beginning of the leader election.
   const RaftConfigPB config_;
 
-  // UUID to region map derived from RaftConfigPB.
-  std::map<std::string, std::string> uuid_to_region_;
+  // UUID to quorum_id map derived from RaftConfigPB.
+  std::map<std::string, std::string> uuid_to_quorum_id_;
 
   // UUID to last term pruned mapping.
   std::map<std::string, int64_t> uuid_to_last_term_pruned_;

--- a/src/kudu/consensus/metadata.proto
+++ b/src/kudu/consensus/metadata.proto
@@ -48,6 +48,9 @@ message RaftPeerAttrsPB {
 
   // The mysql/bls server id
   optional uint32 server_id = 6 [ default = 0 ];
+
+  // Define which quorum the peer belongs to in Flexiraft under use_quorum_id
+  optional string quorum_id = 7;
 }
 
 // Report on a replica's (peer's) health.
@@ -86,6 +89,11 @@ enum QuorumMode {
   SINGLE_REGION_DYNAMIC = 2;
 }
 
+enum QuorumType {
+  REGION = 0;
+  QUORUM_ID = 1;
+}
+
 // Analogue of CommitRulePredicate on the plugin.
 // Defines a single predicate in the static quorum modes.
 // The predicates are of the form:
@@ -101,6 +109,8 @@ message CommitRulePredicatePB {
 message CommitRulePB {
   required QuorumMode mode = 1;
   repeated CommitRulePredicatePB rule_predicates = 2;
+  // Use quorum_id instead of region for flexiraft quorum
+  optional QuorumType quorum_type = 3;
 }
 
 // Represents the arrangement of master and its slaves for a MySQL replica set.

--- a/src/kudu/consensus/metadata.proto
+++ b/src/kudu/consensus/metadata.proto
@@ -49,7 +49,8 @@ message RaftPeerAttrsPB {
   // The mysql/bls server id
   optional uint32 server_id = 6 [ default = 0 ];
 
-  // Define which quorum the peer belongs to in Flexiraft under use_quorum_id
+  // Define which quorum the peer belongs to in Flexiraft when using
+  // QuorumType::QUORUM_ID
   optional string quorum_id = 7;
 }
 

--- a/src/kudu/consensus/quorum_util.cc
+++ b/src/kudu/consensus/quorum_util.cc
@@ -28,6 +28,7 @@
 #include <glog/logging.h>
 
 #include "kudu/common/common.pb.h"
+#include "kudu/consensus/metadata.pb.h"
 #include "kudu/gutil/macros.h"
 #include "kudu/gutil/map-util.h"
 #include "kudu/gutil/port.h"
@@ -35,6 +36,9 @@
 #include "kudu/gutil/strings/substitute.h"
 #include "kudu/util/pb_util.h"
 #include "kudu/util/status.h"
+
+// This is the how META runs quorum for Flexiraft currently
+DEFINE_int32(default_quorum_size, 3, "Default size of quorum when QuorumId is used");
 
 using google::protobuf::RepeatedPtrField;
 using kudu::pb_util::SecureShortDebugString;
@@ -90,6 +94,18 @@ bool GetRaftConfigMemberRegion(const std::string& uuid,
     if (peer.permanent_uuid() == uuid) {
       *is_voter = (peer.member_type() == RaftPeerPB::VOTER);
       *region = peer.attrs().region();
+      return true;
+    }
+  }
+  return false;
+}
+
+bool GetRaftConfigMemberQuorumId(const std::string& uuid,
+    const RaftConfigPB& config, bool *is_voter, std::string *quorum_id) {
+  for (const RaftPeerPB& peer : config.peers()) {
+    if (peer.permanent_uuid() == uuid) {
+      *is_voter = (peer.member_type() == RaftPeerPB::VOTER);
+      *quorum_id = GetQuorumId(peer, config.commit_rule());
       return true;
     }
   }
@@ -866,25 +882,33 @@ bool ShouldEvictReplica(const RaftConfigPB& config,
   return should_evict;
 }
 
-void GetRegionalCountsFromConfig(
+void GetActualVoterCountsFromConfig(
     const RaftConfigPB& config, const std::string& leader_uuid,
-    std::map<std::string, int>* regional_count, std::string* leader_region) {
-  CHECK(regional_count);
-  CHECK(leader_uuid.empty() || leader_region != nullptr);
+    std::map<std::string, int>* actual_voter_counts,
+    std::string* leader_quorum_id, bool backed_by_db_only) {
+  CHECK(actual_voter_counts);
+  CHECK(leader_uuid.empty() || leader_quorum_id != nullptr);
+  bool use_quorum_id = IsUseQuorumId(config.commit_rule());
   for (const RaftPeerPB& peer : config.peers()) {
     // Only consider peers that are voters.
     if (!peer.has_member_type() ||
         peer.member_type() != RaftPeerPB::VOTER) {
       continue;
     }
-    CHECK(peer.has_permanent_uuid() && peer.has_attrs() &&
-        peer.attrs().has_region());
-    const std::string& region = peer.attrs().region();
-    int& count = LookupOrInsert(regional_count, region, 0);
+
+    if (backed_by_db_only && peer.has_attrs() &&
+        peer.attrs().has_backing_db_present() &&
+        !peer.attrs().backing_db_present()) {
+      continue;
+    }
+
+    std::string quorum_id = GetQuorumId(peer, use_quorum_id);
+
+    int& count = LookupOrInsert(actual_voter_counts, quorum_id, 0);
     count++;
     if (!leader_uuid.empty() &&
         peer.permanent_uuid() == leader_uuid) {
-      *leader_region = region;
+      *leader_quorum_id = quorum_id;
     }
   }
 }
@@ -897,23 +921,23 @@ void AdjustVoterDistributionWithCurrentVoters(
   // As voter distribution provided in topology config can lag,
   // we need to take into account the active voters as well due to
   // membership changes.
-  std::map<std::string, int> voters_in_config_per_region;
+  std::map<std::string, int> voters_in_config_per_quorum;
   std::string unused_leader_region;
   std::string unused_leader_uuid;
-  GetRegionalCountsFromConfig(
-      config, unused_leader_uuid, &voters_in_config_per_region,
+  GetActualVoterCountsFromConfig(
+      config, unused_leader_uuid, &voters_in_config_per_quorum,
       &unused_leader_region);
 
   std::map<std::string, int>::iterator itr;
   // We will increase the voter distribution to the max of the 2 maps
   for (itr = voter_distribution->begin(); itr != voter_distribution->end(); ++itr) {
-    auto fnditr = voters_in_config_per_region.find(itr->first);
+    auto fnditr = voters_in_config_per_quorum.find(itr->first);
 
     // There is a region in voter distribution which has no voters.
     // We need to remove it, otherwise Pessismistic quorum will be invalid.
     // This can happen during region removals. The voter distribution is
     // still around till the last voter in a region has been deleted.
-    if (fnditr == voters_in_config_per_region.end()) {
+    if (fnditr == voters_in_config_per_quorum.end()) {
       itr = voter_distribution->erase(itr);
       continue;
     }
@@ -922,9 +946,65 @@ void AdjustVoterDistributionWithCurrentVoters(
   }
 }
 
+void GetVoterDistributionForQuorumId(
+    const RaftConfigPB& config,
+    std::map<std::string, int>* quorum_id_vd
+) {
+  if (IsUseQuorumId(config.commit_rule())) {
+    // Step 1: Using the default quorum size
+    for (const auto peer : config.peers()) {
+      if (peer.has_member_type() && peer.member_type() == RaftPeerPB::VOTER) {
+        CHECK(peer.has_attrs() && peer.attrs().has_quorum_id());
+        InsertIfNotPresent(quorum_id_vd, peer.attrs().quorum_id(), FLAGS_default_quorum_size);
+      }
+    }
+
+    // Step 2: Adjust vd based on current vd overrides
+    // quorum_id VD adjustment ignores skew between VD provided in config and actual
+    // quorum_id for each peer in config. In practice, quorum_id should have a unique
+    // prefix to distinguish itself from region. During quorum_id rollout, this code
+    // will ignore region-based VD set by automation, and still uses default 3 for
+    // each quorum.
+    for (const auto original_vd_entry : config.voter_distribution()) {
+      auto it = quorum_id_vd->find(original_vd_entry.first);
+      if (it != quorum_id_vd->end()) {
+        it->second = original_vd_entry.second;
+      }
+    }
+  } else {
+    // For region based, keep vd as it is
+    quorum_id_vd->insert(config.voter_distribution().begin(), config.voter_distribution().end());
+  }
+}
+
 bool IsStaticQuorumMode(QuorumMode mode) {
   return (mode == QuorumMode::STATIC_DISJUNCTION ||
     mode == QuorumMode::STATIC_CONJUNCTION);
+}
+
+bool IsUseQuorumId(const CommitRulePB& commit_rule) {
+  return commit_rule.has_quorum_type() &&
+         commit_rule.quorum_type() == QuorumType::QUORUM_ID;
+}
+
+std::string GetQuorumId(const RaftPeerPB& peer, bool use_quorum_id) {
+  if (use_quorum_id) {
+    if (peer.has_member_type() && peer.member_type() == RaftPeerPB::VOTER) {
+      // Voter must have a quorum_id
+      CHECK(peer.has_attrs() && peer.attrs().has_quorum_id());
+      return peer.attrs().quorum_id();
+    } else {
+      // Non-voter must not have a quorum_id
+      return "";
+    }
+  } else {
+    CHECK(peer.has_attrs() && peer.attrs().has_region());
+    return peer.attrs().region();
+  }
+}
+
+std::string GetQuorumId(const RaftPeerPB& peer, const CommitRulePB& commit_rule) {
+  return GetQuorumId(peer, IsUseQuorumId(commit_rule));
 }
 
 }  // namespace consensus

--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -28,6 +28,7 @@
 #include <cmath>
 #include <cstdint>
 #include <functional>
+#include <glog/logging.h>
 #include <iterator>
 #include <memory>
 #include <mutex>
@@ -188,6 +189,8 @@ DEFINE_bool(enable_flexi_raft, false,
 
 DEFINE_bool(track_removed_peers, true,
             "Should peers removed from the config be tracked for using it in RequestVote()");
+DEFINE_bool(allow_multiple_backed_by_db_per_quorum, false,
+            "Can multiple backed_by_db instances be added to the same quorum");
 
 // Metrics
 // ---------
@@ -626,7 +629,8 @@ Status RaftConsensus::StartElection(ElectionMode mode, ElectionContext context) 
 
     // In flexi raft mode, we want to start elections only in Candidate
     // regions which have voter_distribution Information.
-    if (FLAGS_enable_flexi_raft) {
+    // It can be skipped when using quorum_id
+    if (FLAGS_enable_flexi_raft && !IsUseQuorumId(cmeta_->ActiveConfig().commit_rule())) {
       const auto& vd_map = cmeta_->ActiveConfig().voter_distribution();
       if (PREDICT_FALSE(vd_map.find(peer_region()) == vd_map.end())) {
         return Status::IllegalState(strings::Substitute(
@@ -2318,6 +2322,31 @@ Status RaftConsensus::CheckBulkConfigChangeAndGetNewConfigUnlocked(
             return Status::InvalidArgument("peer must have last_known_addr specified",
                                            SecureShortDebugString(req));
           }
+          if (peer.member_type() != RaftPeerPB::VOTER && peer.has_attrs() &&
+              peer.attrs().has_quorum_id() && peer.attrs().quorum_id() != "") {
+            return Status::InvalidArgument("Non-voter must not have quorum_id",
+                                           SecureShortDebugString(req));
+          }
+
+          // In quorum_id is enabled, we have an option to disallow multiple MySQL instances
+          // being added to the same quorum
+          if (FLAGS_enable_flexi_raft && IsUseQuorumId(committed_config.commit_rule()) &&
+              !FLAGS_allow_multiple_backed_by_db_per_quorum) {
+            std::string leader_uuid_unused;
+            // A map from quorum id to actual number of backed_by_db voters in config
+            std::map<std::string, int> actual_bbd_voter_counts;
+            GetActualVoterCountsFromConfig(committed_config, leader_uuid_unused,
+              &actual_bbd_voter_counts, /* leader_quorum_id */ nullptr,
+              /* backed_by_db_only */ true);
+            std::string peer_quorum_id = GetQuorumId(peer, /* use_quorum_id */ true);
+            int count = FindWithDefault(actual_bbd_voter_counts, peer_quorum_id, 0);
+            if (count >= 1) {
+              return Status::AlreadyPresent("Not allow multiple backed_by_db instance "
+                                            "added to the same quorum.",
+                                            SecureShortDebugString(req));
+            }
+          }
+
           if (peer.member_type() == RaftPeerPB::VOTER) {
             num_voters_modified++;
           }
@@ -2353,15 +2382,16 @@ Status RaftConsensus::CheckBulkConfigChangeAndGetNewConfigUnlocked(
             // requirement, because it gives flexibility to automation to replace nodes without
             // impacting the write availability.
             if (FLAGS_enable_flexi_raft) {
-              const auto& vd_map = committed_config.voter_distribution();
+              std::map<std::string, int> vd_map;
+              GetVoterDistributionForQuorumId(committed_config, &vd_map);
 
-              std::map<std::string, int> voters_in_config_per_region;
-              std::string unused_leader_region;
+              std::map<std::string, int> voters_in_config_per_quorum;
+              std::string unused_leader_quorum;
               std::string unused_leader_uuid;
               // Get number of voters in each region
-              GetRegionalCountsFromConfig(
-                  committed_config, unused_leader_uuid, &voters_in_config_per_region,
-                  &unused_leader_region);
+              GetActualVoterCountsFromConfig(
+                  committed_config, unused_leader_uuid, &voters_in_config_per_quorum,
+                  &unused_leader_quorum);
 
               // single region dynamic mode.
               bool srd_mode = committed_config.has_commit_rule() &&
@@ -2372,25 +2402,25 @@ Status RaftConsensus::CheckBulkConfigChangeAndGetNewConfigUnlocked(
                 }
 
                 // Zeroed in on the peer we are about to remove.
-                const std::string& region = peer.attrs().region();
+                const std::string& quorum_id = GetQuorumId(peer, cmeta_->ActiveConfig().commit_rule());
 
                 // In SINGLE REGION DYANMIC mode, we only do this extra check
                 // in current LEADER region. the local peer is the LEADER
                 // because of CheckActiveLeaderUnlocked above
-                if (srd_mode && region != peer_region()) {
+                if (srd_mode && quorum_id != peer_quorum_id()) {
                   break;
                 }
-                int current_count = voters_in_config_per_region[region];
+                int current_count = voters_in_config_per_quorum[quorum_id];
                 // reduce count by 1
                 int future_count = current_count - 1;
-                auto vd_itr = vd_map.find(region);
+                auto vd_itr = vd_map.find(quorum_id);
                 if (vd_itr != vd_map.end()) {
                   int expected_voters = (*vd_itr).second;
                   int quorum = MajoritySize(expected_voters);
                   if (future_count < quorum) {
-                    return Status::InvalidArgument(strings::Substitute("Cannot remove a voter in region: $0"
+                    return Status::InvalidArgument(strings::Substitute("Cannot remove a voter in quorum: $0"
                         " which will make future voter count: $1 dip below expected voters: $2",
-                        region, future_count, quorum));
+                        quorum_id, future_count, quorum));
                   }
                 }
                 break;
@@ -3086,6 +3116,10 @@ std::string RaftConsensus::peer_region() const {
   return local_peer_pb_.attrs().region();
 }
 
+std::string RaftConsensus::peer_quorum_id() const {
+  return GetQuorumId(local_peer_pb_, cmeta_->ActiveConfig().commit_rule());
+}
+
 std::pair<string, unsigned int> RaftConsensus::peer_hostport() const {
   if (local_peer_pb_.has_last_known_addr()) {
     const ::kudu::HostPortPB& host_port = local_peer_pb_.last_known_addr();
@@ -3773,8 +3807,13 @@ Status RaftConsensus::ChangeQuorumType(QuorumType type) {
   RaftConfigPB config = cmeta_->ActiveConfig();
   if (type == QuorumType::QUORUM_ID) {
     for (const auto& peer : config.peers()) {
-      if (!peer.has_attrs() || !peer.attrs().has_quorum_id()
-          || peer.attrs().quorum_id() == "") {
+          // We only check voter
+      if (peer.has_member_type() &&
+          peer.member_type() == RaftPeerPB::VOTER &&
+          // Peer quorum_id can not be null or empty
+          !(peer.has_attrs() &&
+          peer.attrs().has_quorum_id() &&
+          peer.attrs().quorum_id() != "")) {
         return Status::ConfigurationError(Substitute(
           "Unable to change QuorumType to QuorumId. "
           "No quorum_id found for peer $0", peer.permanent_uuid()));
@@ -3830,20 +3869,24 @@ Status RaftConsensus::SetPeerQuorumIds(std::map<std::string, std::string> uuid2q
     RETURN_NOT_OK(s);
   }
 
+  // Step 1: Update peers quorum_id in active config
   RaftConfigPB config = cmeta_->ActiveConfig();
   google::protobuf::RepeatedPtrField<RaftPeerPB> modified_peers;
   for (auto peer : config.peers()) {
-    auto it = uuid2quorum_ids.find(peer.permanent_uuid());
-    if (it == uuid2quorum_ids.end()) {
-      // for force = false, we do not allow a voter without quorum_id assigned
-      if (peer.has_member_type() && peer.member_type() == RaftPeerPB::VOTER && !force) {
-        return Status::ConfigurationError(Substitute(
-          "Failed to update quorum_id. "
-          "No quorum_id found for peer $0", peer.permanent_uuid()));
+    if (peer.has_member_type() && peer.has_member_type() == RaftPeerPB::VOTER) {
+      // We only update quorum_id on voters
+      auto it = uuid2quorum_ids.find(peer.permanent_uuid());
+      if (it == uuid2quorum_ids.end()) {
+        // for force = false, we do not allow a voter without quorum_id assigned
+        if (!force) {
+          return Status::ConfigurationError(Substitute(
+            "Failed to update quorum_id. "
+            "No quorum_id found for peer $0", peer.permanent_uuid()));
+        }
+      } else {
+        // If uuid is found, we set corresponding quorun_id
+        peer.mutable_attrs()->set_quorum_id(it->second);
       }
-    } else {
-      // If uuid is found, we set corresponding quorun_id
-      peer.mutable_attrs()->set_quorum_id(it->second);
     }
 
     // We must add every peer, so we do not remove any peer by accident
@@ -3855,6 +3898,16 @@ Status RaftConsensus::SetPeerQuorumIds(std::map<std::string, std::string> uuid2q
   cmeta_->set_active_config(std::move(config));
   CHECK_OK(cmeta_->Flush());
 
+  // Step 2: Update this peer's own quorum_id
+  if (IsVoterRole(role())) {
+    auto it = uuid2quorum_ids.find(local_peer_pb_.permanent_uuid());
+    if (it != uuid2quorum_ids.end()) {
+      local_peer_pb_.mutable_attrs()->set_quorum_id(it->second);
+    }
+  }
+
+  // Step 3: Update peer quorum_id in consensus queue
+  queue_->UpdatePeerQuorumIdUnlocked(uuid2quorum_ids);
   if (cmeta_->active_role() == RaftPeerPB::LEADER) {
       RETURN_NOT_OK(RefreshConsensusQueueAndPeersUnlocked());
   }

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -492,6 +492,7 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   ProxyTopologyPB GetProxyTopology() const;
 
   // On a live Raft Instance to use quorum_id instead of region for flexiraft
+  // dynamic mode
   Status ChangeQuorumType(QuorumType type);
 
   // Get QuorumType from committed config
@@ -544,6 +545,9 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
 
   // relevant for Flexi-Raft
   std::string peer_region() const;
+
+  // It is own peer region or quorum_id
+  std::string peer_quorum_id() const;
 
   // Returns the id of the tablet whose updates this consensus instance helps coordinate.
   // Thread-safe.
@@ -1111,7 +1115,7 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   const ConsensusOptions options_;
 
   // Information about the local peer, including the local UUID.
-  const RaftPeerPB local_peer_pb_;
+  RaftPeerPB local_peer_pb_;
 
   // Consensus metadata service.
   const scoped_refptr<ConsensusMetadataManager> cmeta_manager_;

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -491,6 +491,22 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   // Return the proxy topology.
   ProxyTopologyPB GetProxyTopology() const;
 
+  // On a live Raft Instance to use quorum_id instead of region for flexiraft
+  Status ChangeQuorumType(QuorumType type);
+
+  // Get QuorumType from committed config
+  QuorumType GetQuorumType() const;
+
+  // Update peer's quorum_id given uuid to quorum_id map. This is an atomic
+  // write, meaning that either all peers in map are updated or none gets
+  // updated.
+  //
+  // When force = false, reject update when use_quorum_id is true or one or more
+  // peers in active config does not exist in the map. Set force = true to
+  // bypass the check.
+  Status SetPeerQuorumIds(std::map<std::string, std::string> uuid2quorum_ids,
+                          bool force = false);
+
   // Only relevant for abstracted logs.
   // Callback the log abstraction's TruncateOpsAfter function
   // while holding Raft Consensus lock. This is to serialize


### PR DESCRIPTION
This PR currently includes both first part of changes and second part of changes. You can start with PR167 and ignore the duplicated in this PR for easier review. You can also review both changes as a whole in this PR if you like.

# Sub-region commit

When commit use_quorum_id is true, quorum is defined by quorum_id, where the MySQL instance and its two LBUs should have the same quorum_id. In peer attribute, each peer has the unchanged region property, plus the new quorum_id.  Commit watermark calculation and leader election calculation is based on quorum_id instead of region. 

## Changes in this PR
1) Whenever attr().region() is used, replaced with a generic function that return region or quorum_id based on commit rule. (Except for proxy and RegionDurableIndex)
2) Add support to edit local_peer's quorum_id as well as tracked peer's quorum_id in consensus queue.

## Tests have done
All the tests from previous PR and
1. Conversion between use_quorum_id
2. Reject append entries on all members, except for the leader its one LBU In a 6-voter region (frc in stage-1 unittestdb), observe commit marker still moving. (commit sub-region is working)
3. Move leadership to a 3-voter region, withhold votes on one frc mysql and its two lbus, and start election on the other frc mysql instance. Observe that frc instance wins election and is able to commit normally. (candidate sub-region is working)