### PR TITLE
Withhold votes from hugely lagging voters in flexiraft SRD mode

### DIFF
--- a/src/kudu/consensus/consensus_meta.cc
+++ b/src/kudu/consensus/consensus_meta.cc
@@ -146,9 +146,11 @@ bool ConsensusMetadata::IsMemberInConfig(const string& uuid,
 bool ConsensusMetadata::IsMemberInConfigWithDetail(
     const std::string& uuid,
     RaftConfigState type,
-    std::string *hostname_port) {
+    std::string *hostname_port,
+    bool *is_voter, std::string *region) {
   DFAKE_SCOPED_RECURSIVE_LOCK(fake_lock_);
-  return IsRaftConfigMemberWithDetail(uuid, GetConfig(type), hostname_port);
+  return IsRaftConfigMemberWithDetail(uuid, GetConfig(type), hostname_port,
+      is_voter, region);
 }
 
 int ConsensusMetadata::CountVotersInConfig(RaftConfigState type) {

--- a/src/kudu/consensus/consensus_meta.h
+++ b/src/kudu/consensus/consensus_meta.h
@@ -94,9 +94,12 @@ class ConsensusMetadata : public RefCountedThreadSafe<ConsensusMetadata> {
   // local Raft config.
   bool IsMemberInConfig(const std::string& uuid, RaftConfigState type);
 
+  // Check that the member is in config and if it is part of the config,
+  // retrieve some key information about the member
   bool IsMemberInConfigWithDetail(const std::string& uuid,
       RaftConfigState type,
-      std::string *hostname_port);
+      std::string *hostname_port,
+      bool *is_voter, std::string *region);
 
   // Returns a count of the number of voters in the specified local Raft
   // config.

--- a/src/kudu/consensus/quorum_util.cc
+++ b/src/kudu/consensus/quorum_util.cc
@@ -60,7 +60,8 @@ bool IsRaftConfigMember(const std::string& uuid, const RaftConfigPB& config) {
 }
 
 bool IsRaftConfigMemberWithDetail(const std::string& uuid,
-    const RaftConfigPB& config, std::string *hostname_port) {
+    const RaftConfigPB& config, std::string *hostname_port,
+    bool *is_voter, std::string *region) {
   for (const RaftPeerPB& peer : config.peers()) {
     if (peer.permanent_uuid() == uuid) {
       const ::kudu::HostPortPB& host_port = peer.last_known_addr();
@@ -69,6 +70,8 @@ bool IsRaftConfigMemberWithDetail(const std::string& uuid,
       } else {
         *hostname_port = Substitute("[$0]:$1", host_port.host(), host_port.port());
       }
+      *is_voter = (peer.member_type() == RaftPeerPB::VOTER);
+      *region = peer.attrs().region();
       return true;
     }
   }

--- a/src/kudu/consensus/quorum_util.h
+++ b/src/kudu/consensus/quorum_util.h
@@ -50,7 +50,8 @@ bool IsRaftConfigVoter(const std::string& uuid, const RaftConfigPB& config);
 bool GetRaftConfigMemberRegion(const std::string& uuid, const RaftConfigPB& config,
     bool *is_voter, std::string *region);
 bool IsRaftConfigMemberWithDetail(const std::string& uuid,
-    const RaftConfigPB& config, std::string *hostname_port);
+    const RaftConfigPB& config, std::string *hostname_port,
+    bool *is_voter, std::string *region);
 
 // Whether the specified Raft role is attributed to a peer which can participate
 // in leader elections.

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -66,6 +66,8 @@
 #include "kudu/util/random.h"
 #include "kudu/util/status_callback.h"
 
+DECLARE_int32(lag_threshold_for_request_vote);
+
 namespace kudu {
 
 typedef std::lock_guard<simple_spinlock> Lock;
@@ -893,6 +895,7 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   // for testing.
   Status RequestVoteRespondVoteWitheld(const VoteRequestPB* request,
                                        const std::string& hostname_port,
+                                       const std::string& withhold_reason,
                                        VoteResponsePB* response);
 
   // Respond to VoteRequest that the vote was not granted because we believe


### PR DESCRIPTION
Summary:

New Non Standard Voting Heuristic: In Flexi Raft, since quorum sizes are typically
small, we have much lesser tolerance for failed nodes. A partially failed
node can be a node which is lagging (say) 10 million opids behind the CANDIDATE.
In normal raft, it will give votes to the CANDIDATE, but if the VOTER is
in same region as CANDIDATE, the VOTER will also soon be part of the write
quorum for the No-Op and needs to be caught up. Hence giving VOTES eagerly
when SELF is much much behind the CANDIDATE, will not help No-Op commit.
So we add another heuristic to address this. Here is how it works
1. It withholds votes if SELF is much behind CANDIDATE.
2. Only applies to flexi raft Single Region dynamic mode
3. Heuristic has a kill switch withhold_votes_on_huge_lag==false
4. Only applies to VOTERs which are in the same region as CANDIDATE

Test Plan: Create test in fbcode.

Reviewers:

Subscribers:

Tasks:

Tags: