### PR TITLE
Backport some changes from fbcode

### DIFF
--- a/src/kudu/consensus/consensus_peers.cc
+++ b/src/kudu/consensus/consensus_peers.cc
@@ -613,7 +613,12 @@ Peer::~Peer() {
   }
 
   // We don't own the ops (the queue does).
+#if GOOGLE_PROTOBUF_VERSION >= 3017003
+  request_.mutable_ops()->UnsafeArenaExtractSubrange(
+      0, request_.ops_size(), nullptr);
+#else
   request_.mutable_ops()->ExtractSubrange(0, request_.ops_size(), nullptr);
+#endif
 }
 
 shared_ptr<PeerProxy> PeerProxyPool::Get(const string& uuid) const {

--- a/src/kudu/consensus/consensus_queue-test.cc
+++ b/src/kudu/consensus/consensus_queue-test.cc
@@ -300,7 +300,12 @@ TEST_F(ConsensusQueueTest, TestStartTrackingAfterStart) {
   ASSERT_EQ(0, request.ops_size());
 
   // extract the ops from the request to avoid double free
+#if GOOGLE_PROTOBUF_VERSION >= 3017003
+  request.mutable_ops()->UnsafeArenaExtractSubrange(
+      0, request.ops_size(), nullptr);
+#else
   request.mutable_ops()->ExtractSubrange(0, request.ops_size(), nullptr);
+#endif
 }
 
 // Tests that the peers gets the messages pages, with the size of a page
@@ -373,7 +378,12 @@ TEST_F(ConsensusQueueTest, TestGetPagedMessages) {
   ASSERT_FALSE(send_more_immediately);
 
   // extract the ops from the request to avoid double free
+#if GOOGLE_PROTOBUF_VERSION >= 3017003
+  request.mutable_ops()->UnsafeArenaExtractSubrange(
+      0, request.ops_size(), nullptr);
+#else
   request.mutable_ops()->ExtractSubrange(0, request.ops_size(), nullptr);
+#endif
 }
 
 TEST_F(ConsensusQueueTest, TestPeersDontAckBeyondWatermarks) {
@@ -440,7 +450,12 @@ TEST_F(ConsensusQueueTest, TestPeersDontAckBeyondWatermarks) {
   ASSERT_EQ(queue_->GetAllReplicatedIndex(), expected.index());
 
   // extract the ops from the request to avoid double free
+#if GOOGLE_PROTOBUF_VERSION >= 3017003
+  request.mutable_ops()->UnsafeArenaExtractSubrange(
+      0, request.ops_size(), nullptr);
+#else
   request.mutable_ops()->ExtractSubrange(0, request.ops_size(), nullptr);
+#endif
 }
 
 TEST_F(ConsensusQueueTest, TestQueueAdvancesCommittedIndex) {
@@ -640,7 +655,12 @@ TEST_F(ConsensusQueueTest, TestQueueLoadsOperationsForPeer) {
   ASSERT_EQ(request.ops_size(), 50);
 
   // The messages still belong to the queue so we have to release them.
+#if GOOGLE_PROTOBUF_VERSION >= 3017003
+  request.mutable_ops()->UnsafeArenaExtractSubrange(
+      0, request.ops().size(), nullptr);
+#else
   request.mutable_ops()->ExtractSubrange(0, request.ops().size(), nullptr);
+#end
 }
 
 // This tests that the queue is able to handle operation overwriting, i.e. when a
@@ -750,7 +770,12 @@ TEST_F(ConsensusQueueTest, TestQueueHandlesOperationOverwriting) {
   ASSERT_EQ(queue_->GetAllReplicatedIndex(), 21);
 
   // The messages still belong to the queue so we have to release them.
+#if GOOGLE_PROTOBUF_VERSION >= 3017003
+  request.mutable_ops()->UnsafeArenaExtractSubrange(
+      0, request.ops().size(), nullptr);
+#else
   request.mutable_ops()->ExtractSubrange(0, request.ops().size(), nullptr);
+#endif
 }
 
 // Test for a bug where we wouldn't move any watermark back, when overwriting
@@ -882,7 +907,12 @@ TEST_F(ConsensusQueueTest, TestOnlyAdvancesWatermarkWhenPeerHasAPrefixOfOurLog) 
 
   // Another request for this peer should get another page of messages. Still not
   // on the queue's term (and thus without advancing watermarks).
+#if GOOGLE_PROTOBUF_VERSION >= 3017003
+  request.mutable_ops()->UnsafeArenaExtractSubrange(
+      0, request.ops().size(), nullptr);
+#else
   request.mutable_ops()->ExtractSubrange(0, request.ops().size(), nullptr);
+#endif
   ASSERT_OK(queue_->RequestForPeer(kPeerUuid, /*read_ops=*/true, &request, &refs, &needs_tablet_copy, &next_hop_uuid));
   ASSERT_FALSE(needs_tablet_copy);
   ASSERT_EQ(request.ops_size(), 9);
@@ -900,7 +930,12 @@ TEST_F(ConsensusQueueTest, TestOnlyAdvancesWatermarkWhenPeerHasAPrefixOfOurLog) 
 
   // The last page of request should overwrite the peer's operations and the
   // response should finally advance the watermarks.
+#if GOOGLE_PROTOBUF_VERSION >= 3017003
+  request.mutable_ops()->UnsafeArenaExtractSubrange(
+      0, request.ops().size(), nullptr);
+#else
   request.mutable_ops()->ExtractSubrange(0, request.ops().size(), nullptr);
+#endif
   ASSERT_OK(queue_->RequestForPeer(kPeerUuid, /*read_ops=*/true, &request, &refs, &needs_tablet_copyi, &next_hop_uuid));
   ASSERT_FALSE(needs_tablet_copy);
   ASSERT_EQ(request.ops_size(), 4);
@@ -915,7 +950,12 @@ TEST_F(ConsensusQueueTest, TestOnlyAdvancesWatermarkWhenPeerHasAPrefixOfOurLog) 
   ASSERT_EQ(queue_->GetMajorityReplicatedIndexForTests(), expected_majority_replicated);
   ASSERT_EQ(queue_->GetAllReplicatedIndex(), expected_all_replicated);
 
+#if GOOGLE_PROTOBUF_VERSION >= 3017003
+  request.mutable_ops()->UnsafeArenaExtractSubrange(
+      0, request.ops().size(), nullptr);
+#else
   request.mutable_ops()->ExtractSubrange(0, request.ops().size(), nullptr);
+#endif
 }
 
 // Test that Tablet Copy is triggered when a "tablet not found" error occurs.

--- a/src/kudu/consensus/consensus_queue.cc
+++ b/src/kudu/consensus/consensus_queue.cc
@@ -721,7 +721,12 @@ Status PeerMessageQueue::RequestForPeer(const string& uuid,
     peer_copy = *peer;
 
     // Clear the requests without deleting the entries, as they may be in use by other peers.
+#if GOOGLE_PROTOBUF_VERSION >= 3017003
+    request->mutable_ops()->UnsafeArenaExtractSubrange(
+        0, request->ops_size(), nullptr);
+#else
     request->mutable_ops()->ExtractSubrange(0, request->ops_size(), nullptr);
+#endif
 
     // This is initialized to the queue's last appended op but gets set to the id of the
     // log entry preceding the first one in 'messages' if messages are found for the peer.

--- a/src/kudu/consensus/log.cc
+++ b/src/kudu/consensus/log.cc
@@ -859,7 +859,12 @@ Status Log::Append(LogEntryPB* entry) {
   if (s.ok()) {
     s = Sync();
   }
+#if GOOGLE_PROTOBUF_VERSION >= 3017003
+  entry_batch.entry_batch_pb_->mutable_entry()->UnsafeArenaExtractSubrange(
+      0, 1, nullptr);
+#else
   entry_batch.entry_batch_pb_->mutable_entry()->ExtractSubrange(0, 1, nullptr);
+#endif
   return s;
 }
 

--- a/src/kudu/consensus/log_util.cc
+++ b/src/kudu/consensus/log_util.cc
@@ -179,8 +179,13 @@ Status LogEntryReader::ReadNextEntry(unique_ptr<LogEntryPB>* entry) {
       }
       recent_entries_.push_back({ offset_, entry->type(), op_id });
     }
+#if GOOGLE_PROTOBUF_VERSION >= 3017003
+    current_batch->mutable_entry()->UnsafeArenaExtractSubrange(
+        0, current_batch->entry_size(), nullptr);
+#else
     current_batch->mutable_entry()->ExtractSubrange(
         0, current_batch->entry_size(), nullptr);
+#endif
   }
 
   *entry = std::move(pending_entries_.front());

--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -1575,10 +1575,15 @@ Status RaftConsensus::CheckLeaderRequestUnlocked(const ConsensusRequestPB* reque
   if (!deduped_req->messages.empty()) {
     // We take ownership of the deduped ops.
     DCHECK_GE(deduped_req->first_message_idx, 0);
+#if GOOGLE_PROTOBUF_VERSION >= 3017003
+    mutable_req->mutable_ops()->UnsafeArenaExtractSubrange(
+        deduped_req->first_message_idx, deduped_req->messages.size(), nullptr);
+#else
     mutable_req->mutable_ops()->ExtractSubrange(
         deduped_req->first_message_idx,
         deduped_req->messages.size(),
         nullptr);
+#endif
   }
 
   RETURN_NOT_OK(s);
@@ -4204,8 +4209,13 @@ void RaftConsensus::HandleProxyRequest(const ConsensusRequestPB* request,
   ConsensusRequestPB downstream_request;
   auto prevent_ops_deletion = MakeScopedCleanup([&]() {
     // Prevent double-deletion of these requests.
+#if GOOGLE_PROTOBUF_VERSION >= 3017003
+    downstream_request.mutable_ops()->UnsafeArenaExtractSubrange(
+        /*start=*/ 0, /*num=*/ downstream_request.ops_size(), /*elements=*/ nullptr);
+#else
     downstream_request.mutable_ops()->ExtractSubrange(
       /*start=*/ 0, /*num=*/ downstream_request.ops_size(), /*elements=*/ nullptr);
+#endif
   });
 
   downstream_request.set_dest_uuid(request->dest_uuid());

--- a/src/kudu/util/mem_tracker.h
+++ b/src/kudu/util/mem_tracker.h
@@ -234,7 +234,7 @@ class MemTrackerAllocator : public Alloc {
   // This allows an allocator<T> to be used for a different type.
   template <class U>
   struct rebind {
-    typedef MemTrackerAllocator<U, typename Alloc::template rebind<U>::other> other;
+    typedef MemTrackerAllocator<U, typename std::allocator_traits<Alloc>::template rebind_alloc<U>> other;
   };
 
   const std::shared_ptr<MemTracker>& mem_tracker() const { return mem_tracker_; }


### PR DESCRIPTION
Summary:

There was some mixup with the synchronization so we have to backport
some of them here.

They're all either put behind compiler flags for fbcode dependencies or
syntactic sugar changes.

Test Plan:

Compile in kuduraft

Reviewers:

Subscribers:

Tasks:

Tags:
Signed-off-by: Yichen <yichenshen@fb.com>