### PR TITLE
Fix a use after move problem

### DIFF
--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -3574,7 +3574,7 @@ Status RaftConsensus::SetRaftRpcToken(boost::optional<std::string> token) {
                                 "we're enforcing token matches");
   }
 
-  persistent_vars_->set_raft_rpc_token(std::move(token));
+  persistent_vars_->set_raft_rpc_token(token);
   CHECK_OK(persistent_vars_->Flush());
 
   LOG_WITH_PREFIX_UNLOCKED(INFO)


### PR DESCRIPTION
Summary:

Shouldn't affect core logic, but logging will likely be broken by this.
Remove the move.

Test Plan:

build in kuduraft

Reviewers:

Subscribers:

Tasks:

Tags:
Signed-off-by: Yichen <yichenshen@fb.com>