### PR TITLE
UCC fix: skip quorum_satisfaction_possible calculate if quorum_satisfied

### DIFF
--- a/src/kudu/consensus/leader_election.cc
+++ b/src/kudu/consensus/leader_election.cc
@@ -419,7 +419,7 @@ FlexibleVoteCounter::IsMajoritySatisfiedInRegions(
           << " but majority requirement is: " << region_majority_size;
       quorum_satisfied = false;
     }
-    if (regional_no_count + region_majority_size > total_region_count) {
+    if (!quorum_satisfied && regional_no_count + region_majority_size > total_region_count) {
       VLOG_WITH_PREFIX(2) << "Quorum satisfaction not possible in region: "
                           << region << " because of excessive no votes: "
                           << regional_no_count


### PR DESCRIPTION
Before this fix: we still calculate quorum_satisfaction_possible when quorum is already satisfied.

It causes an issue for UCC: in a case that all three members in leader region are down. And we set VD[leader_region] = -2. After we start an election, it immediately fails, because "regional_no_count + region_majority_size > total_region_count"  is true (0+0>-2). Then we think last known leader region is not satisfiable, and immediately fail election.

In this fix, if quorum is already satisfied (0>=0), quorum_satisfaction_possible is also always true.