### PR TITLE
Disallow member without quorum_id to join the ring in QuorumId type

### DIFF
--- a/src/kudu/consensus/quorum_util.cc
+++ b/src/kudu/consensus/quorum_util.cc
@@ -1010,5 +1010,10 @@ std::string GetQuorumId(const RaftPeerPB& peer, const CommitRulePB& commit_rule)
   return GetQuorumId(peer, IsUseQuorumId(commit_rule));
 }
 
+bool PeerHasValidQuorumId(const RaftPeerPB &peer) {
+  return peer.has_attrs() && peer.attrs().has_quorum_id() &&
+         !peer.attrs().quorum_id().empty();
+}
+
 }  // namespace consensus
 }  // namespace kudu

--- a/src/kudu/consensus/quorum_util.h
+++ b/src/kudu/consensus/quorum_util.h
@@ -184,6 +184,9 @@ std::string GetQuorumId(const RaftPeerPB& peer, const CommitRulePB& commit_rule)
 // Return quorum_id or region based on whether use quorum_id
 std::string GetQuorumId(const RaftPeerPB& peer, bool use_quorum_id);
 
+// Return true of the peer has a non-empty quorum_id
+bool PeerHasValidQuorumId(const RaftPeerPB& peer);
+
 }  // namespace consensus
 }  // namespace kudu
 


### PR DESCRIPTION
# Summary
1. Refactor quorum_id check to a dedicated function in PeerHasNonEmptyQuorumId()
2. When it is QuorumId type, do not allow voter without quorum_id to join the ring

# Test
Tested in fbcode ring test