### PR TITLE
Back port DCHECK() removal

### DIFF
--- a/src/kudu/consensus/consensus_queue.cc
+++ b/src/kudu/consensus/consensus_queue.cc
@@ -1109,6 +1109,7 @@ int64_t PeerMessageQueue::DoComputeNewWatermarkStaticMode(
 
     for (const std::string& region : rule_predicate.regions()) {
       int total_voters = FindOrDie(voter_distribution, region);
+      DCHECK(total_voters >= 1 || !adjust_voter_distribution_);
       int commit_req = MajoritySize(total_voters);
       std::map<std::string, std::vector<int64_t> >::const_iterator it =
           watermarks_by_region.find(region);
@@ -1289,6 +1290,7 @@ int64_t PeerMessageQueue::ComputeNewWatermarkDynamicMode(int64_t* watermark) {
     total_voters = total_voters_from_voter_distribution;
   }
 
+  DCHECK(total_voters >= 1 || !adjust_voter_distribution_);
   int commit_req = MajoritySize(total_voters);
 
   VLOG_WITH_PREFIX_UNLOCKED(1) << "Computing new commit index in single "

--- a/src/kudu/consensus/quorum_util.cc
+++ b/src/kudu/consensus/quorum_util.cc
@@ -170,7 +170,6 @@ int CountVoters(const RaftConfigPB& config) {
 }
 
 int MajoritySize(int num_voters) {
-  DCHECK_GE(num_voters, 1);
   return (num_voters / 2) + 1;
 }
 


### PR DESCRIPTION
# 1. DCHECK_GE(num_voters, 1);
In UCC, we set VD to -2 , so (-2 / 2) + 1 = 0
However, DCHECK_GE(-2, 1); would aways fails
# 2. DCHECK(has_responded_);
In some cases, say in VD {"atn": 3}, but atn only has one voter. Then that atn starts an election, and all peers responds yes.
Election finishes in the sense that it gets votes from all peers, and LeaderElection destructor is called.
However, there is no ElectionResult yet, because candidate region does not have enough votes. (not satisfied, and still satisfiable).
This check will fail.

# Test
Test and code review has been completed in fbcode