### PR TITLE
Fix crash in vanilla raft

### DIFF
--- a/src/kudu/consensus/raft_consensus.cc
+++ b/src/kudu/consensus/raft_consensus.cc
@@ -2484,7 +2484,7 @@ Status RaftConsensus::CheckBulkConfigChangeAndGetNewConfigUnlocked(
                 // In SINGLE REGION DYANMIC mode, we only do this extra check
                 // in current LEADER region. the local peer is the LEADER
                 // because of CheckActiveLeaderUnlocked above
-                if (srd_mode && quorum_id != peer_quorum_id()) {
+                if (srd_mode && quorum_id != peer_quorum_id(/* need_lock */ false)) {
                   break;
                 }
                 int current_count = voters_in_config_per_quorum[quorum_id];
@@ -3194,8 +3194,14 @@ std::string RaftConsensus::peer_region() const {
   return local_peer_pb_.attrs().region();
 }
 
-std::string RaftConsensus::peer_quorum_id() const {
-  return GetQuorumId(local_peer_pb_, cmeta_->ActiveConfig().commit_rule());
+
+std::string RaftConsensus::peer_quorum_id(bool need_lock) const {
+  if (need_lock) {
+    LockGuard l(lock_);
+  }
+  return cmeta_->ActiveConfig().has_commit_rule() ?
+      GetQuorumId(local_peer_pb_, cmeta_->ActiveConfig().commit_rule()) :
+      "";
 }
 
 std::pair<string, unsigned int> RaftConsensus::peer_hostport() const {

--- a/src/kudu/consensus/raft_consensus.h
+++ b/src/kudu/consensus/raft_consensus.h
@@ -559,7 +559,7 @@ class RaftConsensus : public std::enable_shared_from_this<RaftConsensus>,
   std::string peer_region() const;
 
   // It is own peer region or quorum_id
-  std::string peer_quorum_id() const;
+  std::string peer_quorum_id(bool need_lock = true) const;
 
   // Returns the id of the tablet whose updates this consensus instance helps coordinate.
   // Thread-safe.


### PR DESCRIPTION
# Summary
peer_quorum_id is a raft status var, which may crash when there is no commit rule in vanilla raft.

# Tests
Code review has been completed in fbcode

