### PR TITLE
Rename COMPILE_ASSERT macro and add an ifndef gate to avoid macro redefinition with other identically named macros

### DIFF
--- a/src/kudu/gutil/auxiliary/atomicops-internals-arm-generic.h
+++ b/src/kudu/gutil/auxiliary/atomicops-internals-arm-generic.h
@@ -11,7 +11,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "kudu/gutil/macros.h"  // For COMPILE_ASSERT
+#include "kudu/gutil/macros.h"  // For KUDU_COMPILE_ASSERT
 #include "kudu/gutil/port.h"  // ATTRIBUTE_WEAK
 
 typedef int32_t Atomic32;

--- a/src/kudu/gutil/auxiliary/atomicops-internals-arm-v6plus.h
+++ b/src/kudu/gutil/auxiliary/atomicops-internals-arm-v6plus.h
@@ -12,7 +12,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "kudu/gutil/basictypes.h"  // For COMPILE_ASSERT
+#include "kudu/gutil/basictypes.h"  // For KUDU_COMPILE_ASSERT
 
 // The LDREXD and STREXD instructions in ARM all v7 variants or above.  In v6,
 // only some variants support it.  For simplicity, we only use exclusive

--- a/src/kudu/gutil/auxiliary/atomicops-internals-windows.h
+++ b/src/kudu/gutil/auxiliary/atomicops-internals-windows.h
@@ -11,7 +11,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "kudu/gutil/basictypes.h"  // For COMPILE_ASSERT
+#include "kudu/gutil/basictypes.h"  // For KUDU_COMPILE_ASSERT
 
 typedef int32 Atomic32;
 

--- a/src/kudu/gutil/bind.h
+++ b/src/kudu/gutil/bind.h
@@ -46,7 +46,7 @@
 //
 // TODO(ajwong): We might be able to avoid this now, but need to test.
 //
-// It is possible to move most of the COMPILE_ASSERT asserts into BindState<>,
+// It is possible to move most of the KUDU_COMPILE_ASSERT asserts into BindState<>,
 // but it feels a little nicer to have the asserts here so people do not
 // need to crack open bind_internal.h.  On the other hand, it makes Bind()
 // harder to read.
@@ -95,7 +95,7 @@ Bind(Functor functor, const P1& p1) {
   // non-const reference parameter can make for subtle bugs because the
   // invoked function will receive a reference to the stored copy of the
   // argument and not the original.
-  COMPILE_ASSERT(
+  KUDU_COMPILE_ASSERT(
       !(base::is_non_const_reference<typename
           BoundFunctorTraits::A1Type>::value ),
       do_not_bind_functions_with_nonconst_ref);
@@ -104,11 +104,11 @@ Bind(Functor functor, const P1& p1) {
   // a scoped_refptr because BindState<> itself takes care of AddRef() for
   // methods. We also disallow binding of an array as the method's target
   // object.
-  COMPILE_ASSERT(
+  KUDU_COMPILE_ASSERT(
       internal::HasIsMethodTag<RunnableType>::value ||
           !internal::NeedsScopedRefptrButGetsRawPtr<P1>::value,
       p1_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::HasIsMethodTag<RunnableType>::value ||
+  KUDU_COMPILE_ASSERT(!internal::HasIsMethodTag<RunnableType>::value ||
                      !base::is_array<P1>::value,
                  first_bound_argument_to_method_cannot_be_array);
   typedef internal::BindState<RunnableType, RunType,
@@ -143,7 +143,7 @@ Bind(Functor functor, const P1& p1, const P2& p2) {
   // non-const reference parameter can make for subtle bugs because the
   // invoked function will receive a reference to the stored copy of the
   // argument and not the original.
-  COMPILE_ASSERT(
+  KUDU_COMPILE_ASSERT(
       !(base::is_non_const_reference<typename
           BoundFunctorTraits::A1Type>::value ||
           base::is_non_const_reference<typename
@@ -154,14 +154,14 @@ Bind(Functor functor, const P1& p1, const P2& p2) {
   // a scoped_refptr because BindState<> itself takes care of AddRef() for
   // methods. We also disallow binding of an array as the method's target
   // object.
-  COMPILE_ASSERT(
+  KUDU_COMPILE_ASSERT(
       internal::HasIsMethodTag<RunnableType>::value ||
           !internal::NeedsScopedRefptrButGetsRawPtr<P1>::value,
       p1_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::HasIsMethodTag<RunnableType>::value ||
+  KUDU_COMPILE_ASSERT(!internal::HasIsMethodTag<RunnableType>::value ||
                      !base::is_array<P1>::value,
                  first_bound_argument_to_method_cannot_be_array);
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P2>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P2>::value,
                  p2_is_refcounted_type_and_needs_scoped_refptr);
   typedef internal::BindState<RunnableType, RunType,
       void(typename internal::CallbackParamTraits<P1>::StorageType,
@@ -197,7 +197,7 @@ Bind(Functor functor, const P1& p1, const P2& p2, const P3& p3) {
   // non-const reference parameter can make for subtle bugs because the
   // invoked function will receive a reference to the stored copy of the
   // argument and not the original.
-  COMPILE_ASSERT(
+  KUDU_COMPILE_ASSERT(
       !(base::is_non_const_reference<typename
           BoundFunctorTraits::A1Type>::value ||
           base::is_non_const_reference<typename
@@ -210,16 +210,16 @@ Bind(Functor functor, const P1& p1, const P2& p2, const P3& p3) {
   // a scoped_refptr because BindState<> itself takes care of AddRef() for
   // methods. We also disallow binding of an array as the method's target
   // object.
-  COMPILE_ASSERT(
+  KUDU_COMPILE_ASSERT(
       internal::HasIsMethodTag<RunnableType>::value ||
           !internal::NeedsScopedRefptrButGetsRawPtr<P1>::value,
       p1_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::HasIsMethodTag<RunnableType>::value ||
+  KUDU_COMPILE_ASSERT(!internal::HasIsMethodTag<RunnableType>::value ||
                      !base::is_array<P1>::value,
                  first_bound_argument_to_method_cannot_be_array);
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P2>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P2>::value,
                  p2_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P3>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P3>::value,
                  p3_is_refcounted_type_and_needs_scoped_refptr);
   typedef internal::BindState<RunnableType, RunType,
       void(typename internal::CallbackParamTraits<P1>::StorageType,
@@ -257,7 +257,7 @@ Bind(Functor functor, const P1& p1, const P2& p2, const P3& p3, const P4& p4) {
   // non-const reference parameter can make for subtle bugs because the
   // invoked function will receive a reference to the stored copy of the
   // argument and not the original.
-  COMPILE_ASSERT(
+  KUDU_COMPILE_ASSERT(
       !(base::is_non_const_reference<typename
           BoundFunctorTraits::A1Type>::value ||
           base::is_non_const_reference<typename
@@ -272,18 +272,18 @@ Bind(Functor functor, const P1& p1, const P2& p2, const P3& p3, const P4& p4) {
   // a scoped_refptr because BindState<> itself takes care of AddRef() for
   // methods. We also disallow binding of an array as the method's target
   // object.
-  COMPILE_ASSERT(
+  KUDU_COMPILE_ASSERT(
       internal::HasIsMethodTag<RunnableType>::value ||
           !internal::NeedsScopedRefptrButGetsRawPtr<P1>::value,
       p1_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::HasIsMethodTag<RunnableType>::value ||
+  KUDU_COMPILE_ASSERT(!internal::HasIsMethodTag<RunnableType>::value ||
                      !base::is_array<P1>::value,
                  first_bound_argument_to_method_cannot_be_array);
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P2>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P2>::value,
                  p2_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P3>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P3>::value,
                  p3_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P4>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P4>::value,
                  p4_is_refcounted_type_and_needs_scoped_refptr);
   typedef internal::BindState<RunnableType, RunType,
       void(typename internal::CallbackParamTraits<P1>::StorageType,
@@ -325,7 +325,7 @@ Bind(Functor functor, const P1& p1, const P2& p2, const P3& p3, const P4& p4,
   // non-const reference parameter can make for subtle bugs because the
   // invoked function will receive a reference to the stored copy of the
   // argument and not the original.
-  COMPILE_ASSERT(
+  KUDU_COMPILE_ASSERT(
       !(base::is_non_const_reference<typename
           BoundFunctorTraits::A1Type>::value ||
           base::is_non_const_reference<typename
@@ -342,20 +342,20 @@ Bind(Functor functor, const P1& p1, const P2& p2, const P3& p3, const P4& p4,
   // a scoped_refptr because BindState<> itself takes care of AddRef() for
   // methods. We also disallow binding of an array as the method's target
   // object.
-  COMPILE_ASSERT(
+  KUDU_COMPILE_ASSERT(
       internal::HasIsMethodTag<RunnableType>::value ||
           !internal::NeedsScopedRefptrButGetsRawPtr<P1>::value,
       p1_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::HasIsMethodTag<RunnableType>::value ||
+  KUDU_COMPILE_ASSERT(!internal::HasIsMethodTag<RunnableType>::value ||
                      !base::is_array<P1>::value,
                  first_bound_argument_to_method_cannot_be_array);
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P2>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P2>::value,
                  p2_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P3>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P3>::value,
                  p3_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P4>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P4>::value,
                  p4_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P5>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P5>::value,
                  p5_is_refcounted_type_and_needs_scoped_refptr);
   typedef internal::BindState<RunnableType, RunType,
       void(typename internal::CallbackParamTraits<P1>::StorageType,
@@ -399,7 +399,7 @@ Bind(Functor functor, const P1& p1, const P2& p2, const P3& p3, const P4& p4,
   // non-const reference parameter can make for subtle bugs because the
   // invoked function will receive a reference to the stored copy of the
   // argument and not the original.
-  COMPILE_ASSERT(
+  KUDU_COMPILE_ASSERT(
       !(base::is_non_const_reference<typename
           BoundFunctorTraits::A1Type>::value ||
           base::is_non_const_reference<typename
@@ -418,22 +418,22 @@ Bind(Functor functor, const P1& p1, const P2& p2, const P3& p3, const P4& p4,
   // a scoped_refptr because BindState<> itself takes care of AddRef() for
   // methods. We also disallow binding of an array as the method's target
   // object.
-  COMPILE_ASSERT(
+  KUDU_COMPILE_ASSERT(
       internal::HasIsMethodTag<RunnableType>::value ||
           !internal::NeedsScopedRefptrButGetsRawPtr<P1>::value,
       p1_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::HasIsMethodTag<RunnableType>::value ||
+  KUDU_COMPILE_ASSERT(!internal::HasIsMethodTag<RunnableType>::value ||
                      !base::is_array<P1>::value,
                  first_bound_argument_to_method_cannot_be_array);
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P2>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P2>::value,
                  p2_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P3>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P3>::value,
                  p3_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P4>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P4>::value,
                  p4_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P5>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P5>::value,
                  p5_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P6>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P6>::value,
                  p6_is_refcounted_type_and_needs_scoped_refptr);
   typedef internal::BindState<RunnableType, RunType,
       void(typename internal::CallbackParamTraits<P1>::StorageType,
@@ -479,7 +479,7 @@ Bind(Functor functor, const P1& p1, const P2& p2, const P3& p3, const P4& p4,
   // non-const reference parameter can make for subtle bugs because the
   // invoked function will receive a reference to the stored copy of the
   // argument and not the original.
-  COMPILE_ASSERT(
+  KUDU_COMPILE_ASSERT(
       !(base::is_non_const_reference<typename
           BoundFunctorTraits::A1Type>::value ||
           base::is_non_const_reference<typename
@@ -500,24 +500,24 @@ Bind(Functor functor, const P1& p1, const P2& p2, const P3& p3, const P4& p4,
   // a scoped_refptr because BindState<> itself takes care of AddRef() for
   // methods. We also disallow binding of an array as the method's target
   // object.
-  COMPILE_ASSERT(
+  KUDU_COMPILE_ASSERT(
       internal::HasIsMethodTag<RunnableType>::value ||
           !internal::NeedsScopedRefptrButGetsRawPtr<P1>::value,
       p1_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::HasIsMethodTag<RunnableType>::value ||
+  KUDU_COMPILE_ASSERT(!internal::HasIsMethodTag<RunnableType>::value ||
                      !base::is_array<P1>::value,
                  first_bound_argument_to_method_cannot_be_array);
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P2>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P2>::value,
                  p2_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P3>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P3>::value,
                  p3_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P4>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P4>::value,
                  p4_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P5>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P5>::value,
                  p5_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P6>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P6>::value,
                  p6_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P7>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P7>::value,
                  p7_is_refcounted_type_and_needs_scoped_refptr);
   typedef internal::BindState<RunnableType, RunType,
       void(typename internal::CallbackParamTraits<P1>::StorageType,

--- a/src/kudu/gutil/bind.h.pump
+++ b/src/kudu/gutil/bind.h.pump
@@ -68,7 +68,7 @@ $var MAX_ARITY = 7
 //
 // TODO(ajwong): We might be able to avoid this now, but need to test.
 //
-// It is possible to move most of the COMPILE_ASSERT asserts into BindState<>,
+// It is possible to move most of the KUDU_COMPILE_ASSERT asserts into BindState<>,
 // but it feels a little nicer to have the asserts here so people do not
 // need to crack open bind_internal.h.  On the other hand, it makes Bind()
 // harder to read.
@@ -106,7 +106,7 @@ $if ARITY > 0 [[
   // non-const reference parameter can make for subtle bugs because the
   // invoked function will receive a reference to the stored copy of the
   // argument and not the original.
-  COMPILE_ASSERT(
+  KUDU_COMPILE_ASSERT(
       !($for ARG || [[
 base::is_non_const_reference<typename BoundFunctorTraits::A$(ARG)Type>::value ]]),
       do_not_bind_functions_with_nonconst_ref);
@@ -122,15 +122,15 @@ $if ARG == 1 [[
   // a scoped_refptr because BindState<> itself takes care of AddRef() for
   // methods. We also disallow binding of an array as the method's target
   // object.
-  COMPILE_ASSERT(
+  KUDU_COMPILE_ASSERT(
       internal::HasIsMethodTag<RunnableType>::value ||
           !internal::NeedsScopedRefptrButGetsRawPtr<P$(ARG)>::value,
       p$(ARG)_is_refcounted_type_and_needs_scoped_refptr);
-  COMPILE_ASSERT(!internal::HasIsMethodTag<RunnableType>::value ||
+  KUDU_COMPILE_ASSERT(!internal::HasIsMethodTag<RunnableType>::value ||
                      !base::is_array<P$(ARG)>::value,
                  first_bound_argument_to_method_cannot_be_array);
 ]] $else [[
-  COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P$(ARG)>::value,
+  KUDU_COMPILE_ASSERT(!internal::NeedsScopedRefptrButGetsRawPtr<P$(ARG)>::value,
                  p$(ARG)_is_refcounted_type_and_needs_scoped_refptr);
 ]]  $$ $if ARG
 

--- a/src/kudu/gutil/casts.h
+++ b/src/kudu/gutil/casts.h
@@ -72,7 +72,7 @@ inline To down_cast(From* f) {                   // so we only accept pointers
   // optimized build at run-time, as it will be optimized away
   // completely.
 
-  // TODO(user): This should use COMPILE_ASSERT.
+  // TODO(user): This should use KUDU_COMPILE_ASSERT.
   if (false) {
     ::implicit_cast<From*, To>(NULL);
   }
@@ -92,7 +92,7 @@ inline To down_cast(From* f) {                   // so we only accept pointers
 // compiler will just bind From to const T.
 template<typename To, typename From>
 inline To down_cast(From& f) {
-  COMPILE_ASSERT(base::is_reference<To>::value, target_type_not_a_reference);
+  KUDU_COMPILE_ASSERT(base::is_reference<To>::value, target_type_not_a_reference);
   typedef typename base::remove_reference<To>::type* ToAsPointer;
   if (false) {
     // Compile-time check that To inherits from From. See above for details.
@@ -166,7 +166,7 @@ template <class Dest, class Source>
 inline Dest bit_cast(const Source& source) {
   // Compile time assertion: sizeof(Dest) == sizeof(Source)
   // A compile error here means your Dest and Source have different sizes.
-  COMPILE_ASSERT(sizeof(Dest) == sizeof(Source), VerifySizesAreEqual);
+  KUDU_COMPILE_ASSERT(sizeof(Dest) == sizeof(Source), VerifySizesAreEqual);
 
   Dest dest;
   memcpy(&dest, &source, sizeof(dest));
@@ -252,8 +252,8 @@ class enum_limits<ENUM_TYPE> { \
   static const ENUM_TYPE min_enumerator = ENUM_MIN; \
   static const ENUM_TYPE max_enumerator = ENUM_MAX; \
   static const bool is_specialized = true; \
-  COMPILE_ASSERT(ENUM_MIN >= INT_MIN, enumerator_too_negative_for_int); \
-  COMPILE_ASSERT(ENUM_MAX <= INT_MAX, enumerator_too_positive_for_int); \
+  KUDU_COMPILE_ASSERT(ENUM_MIN >= INT_MIN, enumerator_too_negative_for_int); \
+  KUDU_COMPILE_ASSERT(ENUM_MAX <= INT_MAX, enumerator_too_positive_for_int); \
 };
 
 // The loose enum test/cast is actually the more complicated one,
@@ -283,10 +283,10 @@ class enum_limits<ENUM_TYPE> { \
 
 template <typename Enum>
 inline bool loose_enum_test(int e_val) {
-  COMPILE_ASSERT(enum_limits<Enum>::is_specialized, missing_MAKE_ENUM_LIMITS);
+  KUDU_COMPILE_ASSERT(enum_limits<Enum>::is_specialized, missing_MAKE_ENUM_LIMITS);
   const Enum e_min = enum_limits<Enum>::min_enumerator;
   const Enum e_max = enum_limits<Enum>::max_enumerator;
-  COMPILE_ASSERT(sizeof(e_val) == 4 || sizeof(e_val) == 8, unexpected_int_size);
+  KUDU_COMPILE_ASSERT(sizeof(e_val) == 4 || sizeof(e_val) == 8, unexpected_int_size);
 
   // Find the unary bounding negative number of e_min and e_max.
 
@@ -337,7 +337,7 @@ inline bool loose_enum_test(int e_val) {
 
 template <typename Enum>
 inline bool tight_enum_test(int e_val) {
-  COMPILE_ASSERT(enum_limits<Enum>::is_specialized, missing_MAKE_ENUM_LIMITS);
+  KUDU_COMPILE_ASSERT(enum_limits<Enum>::is_specialized, missing_MAKE_ENUM_LIMITS);
   const Enum e_min = enum_limits<Enum>::min_enumerator;
   const Enum e_max = enum_limits<Enum>::max_enumerator;
   return e_min <= e_val && e_val <= e_max;

--- a/src/kudu/gutil/fixedarray.h
+++ b/src/kudu/gutil/fixedarray.h
@@ -124,7 +124,7 @@ class FixedArray {
   struct InnerContainer {
     T element;
   };
-  COMPILE_ASSERT(sizeof(InnerContainer) == sizeof(T),
+  KUDU_COMPILE_ASSERT(sizeof(InnerContainer) == sizeof(T),
                  fixedarray_inner_container_size_mismatch);
 
   // How many elements should we store inline?

--- a/src/kudu/gutil/gscoped_ptr.h
+++ b/src/kudu/gutil/gscoped_ptr.h
@@ -128,7 +128,7 @@ struct DefaultDeleter {
     //
     // Correct implementation should use SFINAE to disable this
     // constructor. However, since there are no other 1-argument constructors,
-    // using a COMPILE_ASSERT() based on is_convertible<> and requiring
+    // using a KUDU_COMPILE_ASSERT() based on is_convertible<> and requiring
     // complete types is simpler and will cause compile failures for equivalent
     // misuses.
     //
@@ -137,7 +137,7 @@ struct DefaultDeleter {
     // cannot convert to T*.
     enum { T_must_be_complete = sizeof(T) };
     enum { U_must_be_complete = sizeof(U) };
-    COMPILE_ASSERT((base::is_convertible<U*, T*>::value),
+    KUDU_COMPILE_ASSERT((base::is_convertible<U*, T*>::value),
                    U_ptr_must_implicitly_convert_to_T_ptr);
   }
   inline void operator()(T* ptr) const {
@@ -168,7 +168,7 @@ struct DefaultDeleter<T[]> {
 template <class T, int n>
 struct DefaultDeleter<T[n]> {
   // Never allow someone to declare something like gscoped_ptr<int[10]>.
-  COMPILE_ASSERT(sizeof(T) == -1, do_not_use_array_with_size_as_type);
+  KUDU_COMPILE_ASSERT(sizeof(T) == -1, do_not_use_array_with_size_as_type);
 };
 
 // Function object which invokes 'free' on its parameter, which must be
@@ -318,7 +318,7 @@ template <class T, class D = kudu::DefaultDeleter<T> >
 class gscoped_ptr {
   MOVE_ONLY_TYPE_FOR_CPP_03(gscoped_ptr, RValue)
 
-  COMPILE_ASSERT(kudu::internal::IsNotRefCounted<T>::value,
+  KUDU_COMPILE_ASSERT(kudu::internal::IsNotRefCounted<T>::value,
                  T_is_refcounted_type_and_needs_scoped_refptr);
 
  public:
@@ -347,7 +347,7 @@ class gscoped_ptr {
   // implementation of gscoped_ptr.
   template <typename U, typename V>
   gscoped_ptr(gscoped_ptr<U, V> other) : impl_(&other.impl_) {
-    COMPILE_ASSERT(!base::is_array<U>::value, U_cannot_be_an_array);
+    KUDU_COMPILE_ASSERT(!base::is_array<U>::value, U_cannot_be_an_array);
   }
 
   // Constructor.  Move constructor for C++03 move emulation of this type.
@@ -365,7 +365,7 @@ class gscoped_ptr {
   // gscoped_ptr.
   template <typename U, typename V>
   gscoped_ptr& operator=(gscoped_ptr<U, V> rhs) {
-    COMPILE_ASSERT(!base::is_array<U>::value, U_cannot_be_an_array);
+    KUDU_COMPILE_ASSERT(!base::is_array<U>::value, U_cannot_be_an_array);
     impl_.TakeState(&rhs.impl_);
     return *this;
   }

--- a/src/kudu/gutil/hash/builtin_type_hash.h
+++ b/src/kudu/gutil/hash/builtin_type_hash.h
@@ -64,7 +64,7 @@ inline uint64 Hash64FloatWithSeed(float num, uint64 seed) {
   if (num == 0) {
     num = 0;
   }
-  COMPILE_ASSERT(sizeof(float) == sizeof(uint32), float_has_wrong_size);
+  KUDU_COMPILE_ASSERT(sizeof(float) == sizeof(uint32), float_has_wrong_size);
 
   const uint64 kMul = 0xc6a4a7935bd1e995ULL;
 
@@ -80,7 +80,7 @@ inline uint64 Hash64DoubleWithSeed(double num, uint64 seed) {
   if (num == 0) {
     num = 0;
   }
-  COMPILE_ASSERT(sizeof(double) == sizeof(uint64), double_has_wrong_size);
+  KUDU_COMPILE_ASSERT(sizeof(double) == sizeof(uint64), double_has_wrong_size);
 
   const uint64 kMul = 0xc6a4a7935bd1e995ULL;
 

--- a/src/kudu/gutil/macros.h
+++ b/src/kudu/gutil/macros.h
@@ -20,16 +20,16 @@
 #define ABSTRACT = 0
 #endif
 
-// The COMPILE_ASSERT macro can be used to verify that a compile time
+// The KUDU_COMPILE_ASSERT macro can be used to verify that a compile time
 // expression is true. For example, you could use it to verify the
 // size of a static array:
 //
-//   COMPILE_ASSERT(KUDU_ARRAYSIZE(content_type_names) == CONTENT_NUM_TYPES,
+//   KUDU_COMPILE_ASSERT(KUDU_ARRAYSIZE(content_type_names) == CONTENT_NUM_TYPES,
 //                  content_type_names_incorrect_size);
 //
 // or to make sure a struct is smaller than a certain size:
 //
-//   COMPILE_ASSERT(sizeof(foo) < 128, foo_too_large);
+//   KUDU_COMPILE_ASSERT(sizeof(foo) < 128, foo_too_large);
 //
 // The second argument to the macro is the name of the variable. If
 // the expression is false, most compilers will issue a warning/error
@@ -39,17 +39,17 @@ template <bool>
 struct CompileAssert {
 };
 
-#define COMPILE_ASSERT(expr, msg) \
+#define KUDU_COMPILE_ASSERT(expr, msg) \
   typedef CompileAssert<(bool(expr))> msg[bool(expr) ? 1 : -1] ATTRIBUTE_UNUSED
 
-// Implementation details of COMPILE_ASSERT:
+// Implementation details of KUDU_COMPILE_ASSERT:
 //
-// - COMPILE_ASSERT works by defining an array type that has -1
+// - KUDU_COMPILE_ASSERT works by defining an array type that has -1
 //   elements (and thus is invalid) when the expression is false.
 //
 // - The simpler definition
 //
-//     #define COMPILE_ASSERT(expr, msg) typedef char msg[(expr) ? 1 : -1]
+//     #define KUDU_COMPILE_ASSERT(expr, msg) typedef char msg[(expr) ? 1 : -1]
 //
 //   does not work, as gcc supports variable-length arrays whose sizes
 //   are determined at run-time (this is gcc's extension and not part
@@ -57,7 +57,7 @@ struct CompileAssert {
 //   following code with the simple definition:
 //
 //     int foo;
-//     COMPILE_ASSERT(foo, msg); // not supposed to compile as foo is
+//     KUDU_COMPILE_ASSERT(foo, msg); // not supposed to compile as foo is
 //                               // not a compile-time constant.
 //
 // - By using the type CompileAssert<(bool(expr))>, we ensures that
@@ -71,7 +71,7 @@ struct CompileAssert {
 //
 //   instead, these compilers will refuse to compile
 //
-//     COMPILE_ASSERT(5 > 0, some_message);
+//     KUDU_COMPILE_ASSERT(5 > 0, some_message);
 //
 //   (They seem to think the ">" in "5 > 0" marks the end of the
 //   template argument list.)

--- a/src/kudu/gutil/spinlock.h
+++ b/src/kudu/gutil/spinlock.h
@@ -145,7 +145,7 @@ class SCOPED_LOCKABLE SpinLockHolder {
   inline ~SpinLockHolder() /*UNLOCK_FUNCTION()*/ { lock_->Unlock(); }
 };
 // Catch bug where variable name is omitted, e.g. SpinLockHolder (&lock);
-#define SpinLockHolder(x) COMPILE_ASSERT(0, spin_lock_decl_missing_var_name)
+#define SpinLockHolder(x) KUDU_COMPILE_ASSERT(0, spin_lock_decl_missing_var_name)
 
 } // namespace base
 

--- a/src/kudu/gutil/stringprintf.cc
+++ b/src/kudu/gutil/stringprintf.cc
@@ -126,9 +126,9 @@ string StringPrintfVector(const char* format, const vector<string>& v) {
   // I do not know any way to pass kStringPrintfVectorMaxArgs arguments,
   // or any way to build a va_list by hand, or any API for printf
   // that accepts an array of arguments.  The best I can do is stick
-  // this COMPILE_ASSERT right next to the actual statement.
+  // this KUDU_COMPILE_ASSERT right next to the actual statement.
 
-  COMPILE_ASSERT(kStringPrintfVectorMaxArgs == 32, arg_count_mismatch);
+  KUDU_COMPILE_ASSERT(kStringPrintfVectorMaxArgs == 32, arg_count_mismatch);
   return StringPrintf(format,
                       cstr[0], cstr[1], cstr[2], cstr[3], cstr[4],
                       cstr[5], cstr[6], cstr[7], cstr[8], cstr[9],

--- a/src/kudu/gutil/strings/numbers.cc
+++ b/src/kudu/gutil/strings/numbers.cc
@@ -1269,7 +1269,7 @@ char* DoubleToBuffer(double value, char* buffer) {
   // platforms these days.  Just in case some system exists where DBL_DIG
   // is significantly larger -- and risks overflowing our buffer -- we have
   // this assert.
-  COMPILE_ASSERT(DBL_DIG < 20, DBL_DIG_is_too_big);
+  KUDU_COMPILE_ASSERT(DBL_DIG < 20, DBL_DIG_is_too_big);
 
   int snprintf_result =
     snprintf(buffer, kDoubleToBufferSize, "%.*g", DBL_DIG, value);
@@ -1293,7 +1293,7 @@ char* FloatToBuffer(float value, char* buffer) {
   // platforms these days.  Just in case some system exists where FLT_DIG
   // is significantly larger -- and risks overflowing our buffer -- we have
   // this assert.
-  COMPILE_ASSERT(FLT_DIG < 10, FLT_DIG_is_too_big);
+  KUDU_COMPILE_ASSERT(FLT_DIG < 10, FLT_DIG_is_too_big);
 
   int snprintf_result =
     snprintf(buffer, kFloatToBufferSize, "%.*g", FLT_DIG, value);

--- a/src/kudu/gutil/strings/numbers.h
+++ b/src/kudu/gutil/strings/numbers.h
@@ -409,7 +409,7 @@ inline std::string SimpleItoa(unsigned __int128 i) {
 template <typename int_type>
 bool MUST_USE_RESULT SimpleAtoi(const char* s, int_type* out) {
   // Must be of integer type (not pointer type), with more than 16-bitwidth.
-  COMPILE_ASSERT(sizeof(*out) == 4 || sizeof(*out) == 8,
+  KUDU_COMPILE_ASSERT(sizeof(*out) == 4 || sizeof(*out) == 8,
                  SimpleAtoiWorksWith32Or64BitInts);
   if (std::numeric_limits<int_type>::is_signed) {  // Signed
     if (sizeof(*out) == 64 / 8) {  // 64-bit

--- a/src/kudu/gutil/strings/substitute.cc
+++ b/src/kudu/gutil/strings/substitute.cc
@@ -115,7 +115,7 @@ void SubstituteAndAppend(
 }
 
 SubstituteArg::SubstituteArg(const void* value) {
-  COMPILE_ASSERT(sizeof(scratch_) >= sizeof(value) * 2 + 2,
+  KUDU_COMPILE_ASSERT(sizeof(scratch_) >= sizeof(value) * 2 + 2,
                  fix_sizeof_scratch_);
   if (value == nullptr) {
     text_ = "NULL";

--- a/src/kudu/gutil/strtoint.h
+++ b/src/kudu/gutil/strtoint.h
@@ -59,13 +59,13 @@ inline uint32 strtou32(const char *nptr, char **endptr, int base) {
 // For now, long long is 64-bit on all the platforms we care about, so these
 // functions can simply pass the call to strto[u]ll.
 inline int64 strto64(const char *nptr, char **endptr, int base) {
-  COMPILE_ASSERT(sizeof(int64) == sizeof(long long),
+  KUDU_COMPILE_ASSERT(sizeof(int64) == sizeof(long long),
                  sizeof_int64_is_not_sizeof_long_long);
   return strtoll(nptr, endptr, base);
 }
 
 inline uint64 strtou64(const char *nptr, char **endptr, int base) {
-  COMPILE_ASSERT(sizeof(uint64) == sizeof(unsigned long long),
+  KUDU_COMPILE_ASSERT(sizeof(uint64) == sizeof(unsigned long long),
                  sizeof_uint64_is_not_sizeof_long_long);
   return strtoull(nptr, endptr, base);
 }

--- a/src/kudu/util/flag_tags.h
+++ b/src/kudu/util/flag_tags.h
@@ -136,8 +136,8 @@ struct FlagTags {
 // This also validates that 'tag' is a valid flag as defined in the FlagTags
 // enum above.
 #define TAG_FLAG(flag_name, tag) \
-  COMPILE_ASSERT(sizeof(decltype(FLAGS_##flag_name)), flag_does_not_exist); \
-  COMPILE_ASSERT(sizeof(::kudu::FlagTags::tag), invalid_tag);   \
+  KUDU_COMPILE_ASSERT(sizeof(decltype(FLAGS_##flag_name)), flag_does_not_exist); \
+  KUDU_COMPILE_ASSERT(sizeof(::kudu::FlagTags::tag), invalid_tag);   \
   namespace {                                                     \
     ::kudu::flag_tags_internal::FlagTagger t_##flag_name##_##tag( \
         AS_STRING(flag_name), AS_STRING(tag));                    \

--- a/src/kudu/util/status.h
+++ b/src/kudu/util/status.h
@@ -449,7 +449,7 @@ class KUDU_EXPORT Status {
     //
     // TODO: Move error codes into an error_code.proto or something similar.
   };
-  COMPILE_ASSERT(sizeof(Code) == 4, code_enum_size_is_part_of_abi);
+  KUDU_COMPILE_ASSERT(sizeof(Code) == 4, code_enum_size_is_part_of_abi);
 
   Code code() const {
     return (state_ == NULL) ? kOk : static_cast<Code>(state_[4]);


### PR DESCRIPTION
Summary : COMPILE_ASSERT macro clashed in name with a macro defined in cpp-btree leading to LBU target build errors. To avoid such macro redefinition errors, Rename COMPILE_ASSERT macro to KUDU_COMPILE_ASSERT and add an ifndef gate.

Test Plan : buck build