### PR TITLE
If candidate is not in config, get its details from candidate context

### DIFF
--- a/src/kudu/consensus/quorum_util.cc
+++ b/src/kudu/consensus/quorum_util.cc
@@ -68,18 +68,23 @@ bool IsRaftConfigMemberWithDetail(const std::string& uuid,
     bool *is_voter, std::string *region) {
   for (const RaftPeerPB& peer : config.peers()) {
     if (peer.permanent_uuid() == uuid) {
-      const ::kudu::HostPortPB& host_port = peer.last_known_addr();
-      if (!peer.hostname().empty()) {
-        *hostname_port = Substitute("$0:$1", peer.hostname(), host_port.port());
-      } else {
-        *hostname_port = Substitute("[$0]:$1", host_port.host(), host_port.port());
-      }
-      *is_voter = (peer.member_type() == RaftPeerPB::VOTER);
-      *region = peer.attrs().region();
+      GetRaftPeerDetail(peer, hostname_port, is_voter, region);
       return true;
     }
   }
   return false;
+}
+
+void GetRaftPeerDetail(const RaftPeerPB& peer, std::string *hostname_port,
+    bool *is_voter, std::string *region) {
+  const ::kudu::HostPortPB& host_port = peer.last_known_addr();
+  if (!peer.hostname().empty()) {
+    *hostname_port = Substitute("$0:$1", peer.hostname(), host_port.port());
+  } else {
+    *hostname_port = Substitute("[$0]:$1", host_port.host(), host_port.port());
+  }
+  *is_voter = (peer.member_type() == RaftPeerPB::VOTER);
+  *region = peer.attrs().region();
 }
 
 bool IsRaftConfigVoter(const std::string& uuid, const RaftConfigPB& config) {

--- a/src/kudu/consensus/quorum_util.h
+++ b/src/kudu/consensus/quorum_util.h
@@ -54,6 +54,8 @@ bool GetRaftConfigMemberQuorumId(const std::string& uuid, const RaftConfigPB& co
 bool IsRaftConfigMemberWithDetail(const std::string& uuid,
     const RaftConfigPB& config, std::string *hostname_port,
     bool *is_voter, std::string *region);
+void GetRaftPeerDetail(const RaftPeerPB& peer, std::string *hostname_port,
+    bool *is_voter, std::string *region);
 
 // Whether the specified Raft role is attributed to a peer which can participate
 // in leader elections.


### PR DESCRIPTION
Summary:
During Recent Prod Issue we had a situation where certain instances
in the ring (LBUs) were severely lagging behind because the LEADER
had purged its logs. When another caught up instance in the same
region as these broken instances asked for VOTES, the lag check
did not kick in as the configuration had chanegd and the CANDIDATE
was NOT-IN-CONFIG (We could not figure out if the candidate was
in same region as the VOTER/lagging instance).

Fallback Approach for NOT-IN-CONFIG:
Since CANDIDATE CONTEXT is always sent, we can fallback on it to
figure out candidate_region, candidate hostname_port and is_candidate_voter.
In this patch, we implement this fallback.

Test Plan:
Test in merlin with deploying new plugin and then create the
same situation.

1. inject lag beyond a threshold where votes should be rejected
2. Do a config change.. adding a new member in same region as the LAGGED instances.
3. Try to transfer leadership to same region caught up new instance.

Prior to this fix, the new instance will win election and get stuck in No-Op commit.

After this fix, the new instance does not win elections.

  Tested on replicaset mysql.replicaset.154673 in PRN region
  After deploying BLS binary, the BLS binary rejected the vote, even when it was not in config.

  I0926 04:12:59.627530 1832892 leader_election.cc:1493] T 00000000000000000000000000000000 P bda1ca71-3d86-11ed-97fb-22d0aceb9838 [CANDIDATE]: Term 129 pre-election: Vote denied by peer lbu4308.prn5:5640(2e3513ca-c783-4e99-b24c-eab4ec0b4c19). Message: Invalid argument: T 00000000000000000000000000000000 P 2e3513ca-c783-4e99-b24c-eab4ec0b4c19 [term 127 FOLLOWER]: Leader pre-election vote request: Denying pre-vote to candidate [NOT-IN-CONFIG] (unittestdb180.prn6:5308) bda1ca71-3d86-11ed-97fb-22d0aceb9838 for term 129 because of reason: votes are being witheld for huge lag 1091609 > 200000, candidate at: term: 127 index: 18904257301, voter at: term: 125 index: 18903165692. Candidate context: Candidate host 2401:db00:006c:6013:face:0000:0069:0000.  Candidate port 5308..

Reviewed By: abhinav04sharma

Differential Revision: D39622520

