### PR TITLE
Fix deprecated unittest asserts

### DIFF
--- a/build-support/iwyu/iwyu_tool.py
+++ b/build-support/iwyu/iwyu_tool.py
@@ -196,22 +196,22 @@ def workaround_parent_dir_relative_includes(cwd, command):
 class RelativeIncludeTest(unittest.TestCase):
     def test(self):
         f = workaround_parent_dir_relative_includes
-        self.assertEquals(
+        self.assertEqual(
             f("/foo/bar", "gcc -isystem relative/dir"),
             "gcc -isystem /foo/bar/relative/dir",
         )
-        self.assertEquals(
+        self.assertEqual(
             f("/foo/bar", "gcc -I relative/dir"), "gcc -I /foo/bar/relative/dir"
         )
-        self.assertEquals(
+        self.assertEqual(
             f("/foo/bar", "gcc -Irelative/dir"), "gcc -I/foo/bar/relative/dir"
         )
 
-        self.assertEquals(
+        self.assertEqual(
             f("/foo/bar", "gcc -isystem /abs/dir"), "gcc -isystem /abs/dir"
         )
-        self.assertEquals(f("/foo/bar", "gcc -I /abs/dir"), "gcc -I /abs/dir")
-        self.assertEquals(f("/foo/bar", "gcc -I/abs/dir"), "gcc -I/abs/dir")
+        self.assertEqual(f("/foo/bar", "gcc -I /abs/dir"), "gcc -I /abs/dir")
+        self.assertEqual(f("/foo/bar", "gcc -I/abs/dir"), "gcc -I/abs/dir")
 
 
 def main(compilation_db_path, source_files, verbose, formatter, iwyu_args):

--- a/build-support/parse_test_failure.py
+++ b/build-support/parse_test_failure.py
@@ -320,7 +320,7 @@ class Test(unittest.TestCase):
             with open(path, "w") as f:
                 f.write(got_value)
         else:
-            self.assertEquals(got_value, open(path).read())
+            self.assertEqual(got_value, open(path).read())
 
 
 def main():


### PR DESCRIPTION
Summary:
In Python 3.2+, a number of asserts were deprecated in the unittest module: https://docs.python.org/3/library/unittest.html#deprecated-aliases.

In Python 3.12, these asserts were deleted completely.
The files in this diff still use the deprecated asserts.

This codemod attempts to fix uses of the deprecated asserts, replacing them with non-deprecated equivalents. It is a naive codemod, using sed.

Differential Revision: D72616297


